### PR TITLE
Bug Resolution: Prompt Templates begin with [Object object]

### DIFF
--- a/src/components/Chat/ChatContent/Message/CommandPrompt/CommandPrompt.tsx
+++ b/src/components/Chat/ChatContent/Message/CommandPrompt/CommandPrompt.tsx
@@ -70,7 +70,7 @@ const CommandPrompt = ({
             <li
               className='px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white cursor-pointer text-start w-full'
               onClick={() => {
-                _setContent((prev) => [{type: 'text', text: prev + cp.prompt}, ...prev.slice(1)]);
+                _setContent([{type: 'text', text: cp.prompt}]);
                 setDropDown(false);
               }}
               key={cp.id}


### PR DESCRIPTION
## Reason
Remove bug where the useState setter is passed a function that results in [Object object] being added to the input

## Description of Bug
When attempting to use the `CommandPrompt` component features of template prompts, the user encounters that when a prompt is clicked, `[Object object]` may input before the prompt data.

## Replication of Bug
1. Follow steps to start a local session or access the [online version](https://animalnots.github.io/BetterChatGPT-PLUS/)
2. Move cursor to the `[/]` icon below the user input box
3. Click on the default "English Translator" prompt

## Visual of Bug
![Screenshot](https://github.com/user-attachments/assets/38304fad-3631-4ee1-a6dd-4489a28cfa90)