### PR TITLE
Add the new Claude 4 Opus and Sonnet models

### DIFF
--- a/public/models.json
+++ b/public/models.json
@@ -15,6 +15,7 @@
       "context_length": 32768,
       "created": 1719273600,
       "description": "The Yi Large model was designed by 01.AI with the following usecases in mind: knowledge search, data classification, human-like chat bots, and customer service.\n\nIt stands out for its multilingual proficiency, particularly in Spanish, Chinese, Japanese, German, and French.\n\nCheck out the [launch announcement](https://01-ai.github.io/blog/01.ai-yi-large-llm-launch) to learn more.",
+      "hugging_face_id": null,
       "id": "01-ai/yi-large",
       "name": "01.AI: Yi Large",
       "per_request_limits": null,
@@ -26,6 +27,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "response_format",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -47,6 +63,7 @@
       "context_length": 16384,
       "created": 1723507200,
       "description": "Starcannon 12B v2 is a creative roleplay and story writing model, based on Mistral Nemo, using [nothingiisreal/mn-celeste-12b](/nothingiisreal/mn-celeste-12b) as a base, with [intervitens/mini-magnum-12b-v1.1](https://huggingface.co/intervitens/mini-magnum-12b-v1.1) merged in using the [TIES](https://arxiv.org/abs/2306.01708) method.\n\nAlthough more similar to Magnum overall, the model remains very creative, with a pleasant writing style. It is recommended for people wanting more variety than Magnum, and yet more verbose prose than Celeste.",
+      "hugging_face_id": "aetherwiing/MN-12B-Starcannon-v2",
       "id": "aetherwiing/mn-starcannon-12b",
       "name": "Aetherwiing: Starcannon 12B",
       "per_request_limits": null,
@@ -58,6 +75,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -79,6 +108,7 @@
       "context_length": 96000,
       "created": 1744555395,
       "description": "DeepCoder-14B-Preview is a 14B parameter code generation model fine-tuned from DeepSeek-R1-Distill-Qwen-14B using reinforcement learning with GRPO+ and iterative context lengthening. It is optimized for long-context program synthesis and achieves strong performance across coding benchmarks, including 60.6% on LiveCodeBench v5, competitive with models like o3-Mini",
+      "hugging_face_id": "agentica-org/DeepCoder-14B-Preview",
       "id": "agentica-org/deepcoder-14b-preview:free",
       "name": "Agentica: Deepcoder 14B Preview (free)",
       "per_request_limits": null,
@@ -90,6 +120,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 96000,
         "is_moderated": false,
@@ -109,72 +156,9 @@
         "tokenizer": "Other"
       },
       "context_length": 256000,
-      "created": 1724371200,
-      "description": "Jamba 1.5 Large is part of AI21's new family of open models, offering superior speed, efficiency, and quality.\n\nIt features a 256K effective context window, the longest among open models, enabling improved performance on tasks like document summarization and analysis.\n\nBuilt on a novel SSM-Transformer architecture, it outperforms larger models like Llama 3.1 70B on benchmarks while maintaining resource efficiency.\n\nRead their [announcement](https://www.ai21.com/blog/announcing-jamba-model-family) to learn more.",
-      "id": "ai21/jamba-1-5-large",
-      "name": "AI21: Jamba 1.5 Large",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000008",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.000002",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 256000,
-        "is_moderated": false,
-        "max_completion_tokens": 4096
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 256000,
-      "created": 1724371200,
-      "description": "Jamba 1.5 Mini is the world's first production-grade Mamba-based model, combining SSM and Transformer architectures for a 256K context window and high efficiency.\n\nIt works with 9 languages and can handle various writing and analysis tasks as well as or better than similar small models.\n\nThis model uses less computer memory and works faster with longer texts than previous designs.\n\nRead their [announcement](https://www.ai21.com/blog/announcing-jamba-model-family) to learn more.",
-      "id": "ai21/jamba-1-5-mini",
-      "name": "AI21: Jamba 1.5 Mini",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000004",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.0000002",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 256000,
-        "is_moderated": false,
-        "max_completion_tokens": 4096
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 256000,
       "created": 1741905173,
       "description": "AI21 Jamba Large 1.6 is a high-performance hybrid foundation model combining State Space Models (Mamba) with Transformer attention mechanisms. Developed by AI21, it excels in extremely long-context handling (256K tokens), demonstrates superior inference efficiency (up to 2.5x faster than comparable models), and supports structured JSON output and tool-use capabilities. It has 94 billion active parameters (398 billion total), optimized quantization support (ExpertsInt8), and multilingual proficiency in languages such as English, Spanish, French, Portuguese, Italian, Dutch, German, Arabic, and Hebrew.\n\nUsage of this model is subject to the [Jamba Open Model License](https://www.ai21.com/licenses/jamba-open-model-license).",
+      "hugging_face_id": "ai21labs/AI21-Jamba-Large-1.6",
       "id": "ai21/jamba-1.6-large",
       "name": "AI21: Jamba 1.6 Large",
       "per_request_limits": null,
@@ -186,38 +170,14 @@
         "request": "0",
         "web_search": "0"
       },
-      "top_provider": {
-        "context_length": 256000,
-        "is_moderated": false,
-        "max_completion_tokens": 4096
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 256000,
-      "created": 1719273600,
-      "description": "The Jamba-Instruct model, introduced by AI21 Labs, is an instruction-tuned variant of their hybrid SSM-Transformer Jamba model, specifically optimized for enterprise applications.\n\n- 256K Context Window: It can process extensive information, equivalent to a 400-page novel, which is beneficial for tasks involving large documents such as financial reports or legal documents\n- Safety and Accuracy: Jamba-Instruct is designed with enhanced safety features to ensure secure deployment in enterprise environments, reducing the risk and cost of implementation\n\nRead their [announcement](https://www.ai21.com/blog/announcing-jamba) to learn more.\n\nJamba has a knowledge cutoff of February 2024.",
-      "id": "ai21/jamba-instruct",
-      "name": "AI21: Jamba Instruct",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000007",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.0000005",
-        "request": "0",
-        "web_search": "0"
-      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 256000,
         "is_moderated": false,
@@ -239,6 +199,7 @@
       "context_length": 256000,
       "created": 1741905171,
       "description": "AI21 Jamba Mini 1.6 is a hybrid foundation model combining State Space Models (Mamba) with Transformer attention mechanisms. With 12 billion active parameters (52 billion total), this model excels in extremely long-context tasks (up to 256K tokens) and achieves superior inference efficiency, outperforming comparable open models on tasks such as retrieval-augmented generation (RAG) and grounded question answering. Jamba Mini 1.6 supports multilingual tasks across English, Spanish, French, Portuguese, Italian, Dutch, German, Arabic, and Hebrew, along with structured JSON output and tool-use capabilities.\n\nUsage of this model is subject to the [Jamba Open Model License](https://www.ai21.com/licenses/jamba-open-model-license).",
+      "hugging_face_id": "ai21labs/AI21-Jamba-Mini-1.6",
       "id": "ai21/jamba-1.6-mini",
       "name": "AI21: Jamba Mini 1.6",
       "per_request_limits": null,
@@ -250,6 +211,14 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 256000,
         "is_moderated": false,
@@ -271,6 +240,7 @@
       "context_length": 131072,
       "created": 1738697557,
       "description": "Aion-1.0 is a multi-model system designed for high performance across various tasks, including reasoning and coding. It is built on DeepSeek-R1, augmented with additional models and techniques such as Tree of Thoughts (ToT) and Mixture of Experts (MoE). It is Aion Lab's most powerful reasoning model.",
+      "hugging_face_id": "",
       "id": "aion-labs/aion-1.0",
       "name": "AionLabs: Aion-1.0",
       "per_request_limits": null,
@@ -282,6 +252,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -303,6 +280,7 @@
       "context_length": 131072,
       "created": 1738697107,
       "description": "Aion-1.0-Mini 32B parameter model is a distilled version of the DeepSeek-R1 model, designed for strong performance in reasoning domains such as mathematics, coding, and logic. It is a modified variant of a FuseAI model that outperforms R1-Distill-Qwen-32B and R1-Distill-Llama-70B, with benchmark results available on its [Hugging Face page](https://huggingface.co/FuseAI/FuseO1-DeepSeekR1-QwQ-SkyT1-32B-Preview), independently replicated for verification.",
+      "hugging_face_id": "FuseAI/FuseO1-DeepSeekR1-QwQ-SkyT1-32B-Preview",
       "id": "aion-labs/aion-1.0-mini",
       "name": "AionLabs: Aion-1.0-Mini",
       "per_request_limits": null,
@@ -314,6 +292,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -335,6 +320,7 @@
       "context_length": 32768,
       "created": 1738696718,
       "description": "Aion-RP-Llama-3.1-8B ranks the highest in the character evaluation portion of the RPBench-Auto benchmark, a roleplaying-specific variant of Arena-Hard-Auto, where LLMs evaluate each other’s responses. It is a fine-tuned base model rather than an instruct model, designed to produce more natural and varied writing.",
+      "hugging_face_id": "",
       "id": "aion-labs/aion-rp-llama-3.1-8b",
       "name": "AionLabs: Aion-RP 1.0 (8B)",
       "per_request_limits": null,
@@ -346,6 +332,11 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -357,39 +348,7 @@
         "input_modalities": [
           "text"
         ],
-        "instruct_type": "airoboros",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama2"
-      },
-      "context_length": 4096,
-      "created": 1698537600,
-      "description": "A Llama 2 70B fine-tune using synthetic data (the Airoboros dataset).\n\nCurrently based on [jondurbin/airoboros-l2-70b](https://huggingface.co/jondurbin/airoboros-l2-70b-2.2.1), but might get updated in the future.",
-      "id": "jondurbin/airoboros-l2-70b",
-      "name": "Airoboros 70B",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000005",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.0000005",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 4096,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
+        "instruct_type": "alpaca",
         "modality": "text->text",
         "output_modalities": [
           "text"
@@ -399,6 +358,7 @@
       "context_length": 4096,
       "created": 1744641874,
       "description": "A finetuned 7 billion parameters Code LLaMA - Instruct model to generate Solidity smart contract using 4-bit QLoRA finetuning provided by PEFT library.",
+      "hugging_face_id": "AlfredPros/CodeLlama-7b-Instruct-Solidity",
       "id": "alfredpros/codellama-7b-instruct-solidity",
       "name": "AlfredPros: CodeLLaMa 7B Instruct Solidity",
       "per_request_limits": null,
@@ -410,43 +370,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
         "max_completion_tokens": 4096
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "instruct_type": null,
-        "modality": "text+image->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 4096,
-      "created": 1743023247,
-      "description": "Molmo is a family of open vision-language models developed by the Allen Institute for AI. Molmo models are trained on PixMo, a dataset of 1 million, highly-curated image-text pairs. It has state-of-the-art performance among multimodal models with a similar size while being fully open-source. You can find all models in the Molmo family [here](https://huggingface.co/collections/allenai/molmo-66f379e6fe3b8ef090a8ca19). Learn more about the Molmo family [in the announcement blog post](https://molmo.allenai.org/blog) or the [paper](https://huggingface.co/papers/2409.17146).\n\nMolmo 7B-D is based on [Qwen2-7B](https://huggingface.co/Qwen/Qwen2-7B) and uses [OpenAI CLIP](https://huggingface.co/openai/clip-vit-large-patch14-336) as vision backbone. It performs comfortably between GPT-4V and GPT-4o on both academic benchmarks and human evaluation.\n\nThis checkpoint is a preview of the Molmo release. All artifacts used in creating Molmo (PixMo dataset, training code, evaluations, intermediate checkpoints) will be made available at a later date, furthering our commitment to open-source AI development and reproducibility.",
-      "id": "allenai/molmo-7b-d:free",
-      "name": "AllenAI: Molmo 7B D (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 4096,
-        "is_moderated": false,
-        "max_completion_tokens": null
       }
     },
     {
@@ -465,6 +404,7 @@
       "context_length": 300000,
       "created": 1733437363,
       "description": "Amazon Nova Lite 1.0 is a very low-cost multimodal model from Amazon that focused on fast processing of image, video, and text inputs to generate text output. Amazon Nova Lite can handle real-time customer interactions, document analysis, and visual question-answering tasks with high accuracy.\n\nWith an input context of 300K tokens, it can analyze multiple images or up to 30 minutes of video in a single input.",
+      "hugging_face_id": "",
       "id": "amazon/nova-lite-v1",
       "name": "Amazon: Nova Lite 1.0",
       "per_request_limits": null,
@@ -476,9 +416,17 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 300000,
-        "is_moderated": false,
+        "is_moderated": true,
         "max_completion_tokens": 5120
       }
     },
@@ -497,6 +445,7 @@
       "context_length": 128000,
       "created": 1733437237,
       "description": "Amazon Nova Micro 1.0 is a text-only model that delivers the lowest latency responses in the Amazon Nova family of models at a very low cost. With a context length of 128K tokens and optimized for speed and cost, Amazon Nova Micro excels at tasks such as text summarization, translation, content classification, interactive chat, and brainstorming. It has  simple mathematical reasoning and coding abilities.",
+      "hugging_face_id": "",
       "id": "amazon/nova-micro-v1",
       "name": "Amazon: Nova Micro 1.0",
       "per_request_limits": null,
@@ -508,9 +457,17 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 128000,
-        "is_moderated": false,
+        "is_moderated": true,
         "max_completion_tokens": 5120
       }
     },
@@ -530,6 +487,7 @@
       "context_length": 300000,
       "created": 1733436303,
       "description": "Amazon Nova Pro 1.0 is a capable multimodal model from Amazon focused on providing a combination of accuracy, speed, and cost for a wide range of tasks. As of December 2024, it achieves state-of-the-art performance on key benchmarks including visual question answering (TextVQA) and video understanding (VATEX).\n\nAmazon Nova Pro demonstrates strong capabilities in processing both visual and textual information and at analyzing financial documents.\n\n**NOTE**: Video input is not supported at this time.",
+      "hugging_face_id": "",
       "id": "amazon/nova-pro-v1",
       "name": "Amazon: Nova Pro 1.0",
       "per_request_limits": null,
@@ -541,9 +499,17 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 300000,
-        "is_moderated": false,
+        "is_moderated": true,
         "max_completion_tokens": 5120
       }
     },
@@ -563,6 +529,7 @@
       "context_length": 200000,
       "created": 1710288000,
       "description": "Claude 3 Haiku is Anthropic's fastest and most compact model for\nnear-instant responsiveness. Quick and accurate targeted performance.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/claude-3-haiku)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3-haiku",
       "name": "Anthropic: Claude 3 Haiku",
       "per_request_limits": null,
@@ -576,6 +543,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -598,6 +574,7 @@
       "context_length": 200000,
       "created": 1710288000,
       "description": "Claude 3 Haiku is Anthropic's fastest and most compact model for\nnear-instant responsiveness. Quick and accurate targeted performance.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/claude-3-haiku)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3-haiku:beta",
       "name": "Anthropic: Claude 3 Haiku (self-moderated)",
       "per_request_limits": null,
@@ -611,6 +588,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -633,6 +619,7 @@
       "context_length": 200000,
       "created": 1709596800,
       "description": "Claude 3 Opus is Anthropic's most powerful model for highly complex tasks. It boasts top-level performance, intelligence, fluency, and understanding.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/claude-3-family)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3-opus",
       "name": "Anthropic: Claude 3 Opus",
       "per_request_limits": null,
@@ -646,6 +633,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -668,6 +664,7 @@
       "context_length": 200000,
       "created": 1709596800,
       "description": "Claude 3 Opus is Anthropic's most powerful model for highly complex tasks. It boasts top-level performance, intelligence, fluency, and understanding.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/claude-3-family)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3-opus:beta",
       "name": "Anthropic: Claude 3 Opus (self-moderated)",
       "per_request_limits": null,
@@ -681,6 +678,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -703,6 +709,7 @@
       "context_length": 200000,
       "created": 1709596800,
       "description": "Claude 3 Sonnet is an ideal balance of intelligence and speed for enterprise workloads. Maximum utility at a lower price, dependable, balanced for scaled deployments.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/claude-3-family)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3-sonnet",
       "name": "Anthropic: Claude 3 Sonnet",
       "per_request_limits": null,
@@ -716,6 +723,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -738,6 +754,7 @@
       "context_length": 200000,
       "created": 1709596800,
       "description": "Claude 3 Sonnet is an ideal balance of intelligence and speed for enterprise workloads. Maximum utility at a lower price, dependable, balanced for scaled deployments.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/claude-3-family)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3-sonnet:beta",
       "name": "Anthropic: Claude 3 Sonnet (self-moderated)",
       "per_request_limits": null,
@@ -751,6 +768,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -773,6 +799,7 @@
       "context_length": 200000,
       "created": 1730678400,
       "description": "Claude 3.5 Haiku features offers enhanced capabilities in speed, coding accuracy, and tool use. Engineered to excel in real-time applications, it delivers quick response times that are essential for dynamic tasks such as chat interactions and immediate coding suggestions.\n\nThis makes it highly suitable for environments that demand both speed and precision, such as software development, customer service bots, and data management systems.\n\nThis model is currently pointing to [Claude 3.5 Haiku (2024-10-22)](/anthropic/claude-3-5-haiku-20241022).",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-haiku",
       "name": "Anthropic: Claude 3.5 Haiku",
       "per_request_limits": null,
@@ -786,6 +813,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -808,6 +844,7 @@
       "context_length": 200000,
       "created": 1730678400,
       "description": "Claude 3.5 Haiku features enhancements across all skill sets including coding, tool use, and reasoning. As the fastest model in the Anthropic lineup, it offers rapid response times suitable for applications that require high interactivity and low latency, such as user-facing chatbots and on-the-fly code completions. It also excels in specialized tasks like data extraction and real-time content moderation, making it a versatile tool for a broad range of industries.\n\nIt does not support image inputs.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/3-5-models-and-computer-use)",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-haiku-20241022",
       "name": "Anthropic: Claude 3.5 Haiku (2024-10-22)",
       "per_request_limits": null,
@@ -821,6 +858,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -843,6 +889,7 @@
       "context_length": 200000,
       "created": 1730678400,
       "description": "Claude 3.5 Haiku features enhancements across all skill sets including coding, tool use, and reasoning. As the fastest model in the Anthropic lineup, it offers rapid response times suitable for applications that require high interactivity and low latency, such as user-facing chatbots and on-the-fly code completions. It also excels in specialized tasks like data extraction and real-time content moderation, making it a versatile tool for a broad range of industries.\n\nIt does not support image inputs.\n\nSee the launch announcement and benchmark results [here](https://www.anthropic.com/news/3-5-models-and-computer-use)",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-haiku-20241022:beta",
       "name": "Anthropic: Claude 3.5 Haiku (2024-10-22) (self-moderated)",
       "per_request_limits": null,
@@ -856,6 +903,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -878,6 +934,7 @@
       "context_length": 200000,
       "created": 1730678400,
       "description": "Claude 3.5 Haiku features offers enhanced capabilities in speed, coding accuracy, and tool use. Engineered to excel in real-time applications, it delivers quick response times that are essential for dynamic tasks such as chat interactions and immediate coding suggestions.\n\nThis makes it highly suitable for environments that demand both speed and precision, such as software development, customer service bots, and data management systems.\n\nThis model is currently pointing to [Claude 3.5 Haiku (2024-10-22)](/anthropic/claude-3-5-haiku-20241022).",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-haiku:beta",
       "name": "Anthropic: Claude 3.5 Haiku (self-moderated)",
       "per_request_limits": null,
@@ -891,6 +948,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -913,6 +979,7 @@
       "context_length": 200000,
       "created": 1729555200,
       "description": "New Claude 3.5 Sonnet delivers better-than-Opus capabilities, faster-than-Sonnet speeds, at the same Sonnet prices. Sonnet is particularly good at:\n\n- Coding: Scores ~49% on SWE-Bench Verified, higher than the last best score, and without any fancy prompt scaffolding\n- Data science: Augments human data science expertise; navigates unstructured data while using multiple tools for insights\n- Visual processing: excelling at interpreting charts, graphs, and images, accurately transcribing text to derive insights beyond just the text alone\n- Agentic tasks: exceptional tool use, making it great at agentic tasks (i.e. complex, multi-step problem solving tasks that require engaging with other systems)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-sonnet",
       "name": "Anthropic: Claude 3.5 Sonnet",
       "per_request_limits": null,
@@ -926,6 +993,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -948,6 +1024,7 @@
       "context_length": 200000,
       "created": 1718841600,
       "description": "Claude 3.5 Sonnet delivers better-than-Opus capabilities, faster-than-Sonnet speeds, at the same Sonnet prices. Sonnet is particularly good at:\n\n- Coding: Autonomously writes, edits, and runs code with reasoning and troubleshooting\n- Data science: Augments human data science expertise; navigates unstructured data while using multiple tools for insights\n- Visual processing: excelling at interpreting charts, graphs, and images, accurately transcribing text to derive insights beyond just the text alone\n- Agentic tasks: exceptional tool use, making it great at agentic tasks (i.e. complex, multi-step problem solving tasks that require engaging with other systems)\n\nFor the latest version (2024-10-23), check out [Claude 3.5 Sonnet](/anthropic/claude-3.5-sonnet).\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-sonnet-20240620",
       "name": "Anthropic: Claude 3.5 Sonnet (2024-06-20)",
       "per_request_limits": null,
@@ -961,6 +1038,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -983,6 +1069,7 @@
       "context_length": 200000,
       "created": 1718841600,
       "description": "Claude 3.5 Sonnet delivers better-than-Opus capabilities, faster-than-Sonnet speeds, at the same Sonnet prices. Sonnet is particularly good at:\n\n- Coding: Autonomously writes, edits, and runs code with reasoning and troubleshooting\n- Data science: Augments human data science expertise; navigates unstructured data while using multiple tools for insights\n- Visual processing: excelling at interpreting charts, graphs, and images, accurately transcribing text to derive insights beyond just the text alone\n- Agentic tasks: exceptional tool use, making it great at agentic tasks (i.e. complex, multi-step problem solving tasks that require engaging with other systems)\n\nFor the latest version (2024-10-23), check out [Claude 3.5 Sonnet](/anthropic/claude-3.5-sonnet).\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-sonnet-20240620:beta",
       "name": "Anthropic: Claude 3.5 Sonnet (2024-06-20) (self-moderated)",
       "per_request_limits": null,
@@ -996,6 +1083,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -1018,6 +1114,7 @@
       "context_length": 200000,
       "created": 1729555200,
       "description": "New Claude 3.5 Sonnet delivers better-than-Opus capabilities, faster-than-Sonnet speeds, at the same Sonnet prices. Sonnet is particularly good at:\n\n- Coding: Scores ~49% on SWE-Bench Verified, higher than the last best score, and without any fancy prompt scaffolding\n- Data science: Augments human data science expertise; navigates unstructured data while using multiple tools for insights\n- Visual processing: excelling at interpreting charts, graphs, and images, accurately transcribing text to derive insights beyond just the text alone\n- Agentic tasks: exceptional tool use, making it great at agentic tasks (i.e. complex, multi-step problem solving tasks that require engaging with other systems)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "anthropic/claude-3.5-sonnet:beta",
       "name": "Anthropic: Claude 3.5 Sonnet (self-moderated)",
       "per_request_limits": null,
@@ -1031,6 +1128,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -1053,6 +1159,7 @@
       "context_length": 200000,
       "created": 1740422110,
       "description": "Claude 3.7 Sonnet is an advanced large language model with improved reasoning, coding, and problem-solving capabilities. It introduces a hybrid reasoning approach, allowing users to choose between rapid responses and extended, step-by-step processing for complex tasks. The model demonstrates notable improvements in coding, particularly in front-end development and full-stack updates, and excels in agentic workflows, where it can autonomously navigate multi-step processes. \n\nClaude 3.7 Sonnet maintains performance parity with its predecessor in standard mode while offering an extended reasoning mode for enhanced accuracy in math, coding, and instruction-following tasks.\n\nRead more at the [blog post here](https://www.anthropic.com/news/claude-3-7-sonnet)",
+      "hugging_face_id": "",
       "id": "anthropic/claude-3.7-sonnet",
       "name": "Anthropic: Claude 3.7 Sonnet",
       "per_request_limits": null,
@@ -1066,6 +1173,17 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -1088,6 +1206,7 @@
       "context_length": 200000,
       "created": 1740422110,
       "description": "Claude 3.7 Sonnet is an advanced large language model with improved reasoning, coding, and problem-solving capabilities. It introduces a hybrid reasoning approach, allowing users to choose between rapid responses and extended, step-by-step processing for complex tasks. The model demonstrates notable improvements in coding, particularly in front-end development and full-stack updates, and excels in agentic workflows, where it can autonomously navigate multi-step processes. \n\nClaude 3.7 Sonnet maintains performance parity with its predecessor in standard mode while offering an extended reasoning mode for enhanced accuracy in math, coding, and instruction-following tasks.\n\nRead more at the [blog post here](https://www.anthropic.com/news/claude-3-7-sonnet)",
+      "hugging_face_id": "",
       "id": "anthropic/claude-3.7-sonnet:beta",
       "name": "Anthropic: Claude 3.7 Sonnet (self-moderated)",
       "per_request_limits": null,
@@ -1101,6 +1220,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "stop",
+        "reasoning",
+        "include_reasoning",
+        "tools",
+        "tool_choice"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -1123,6 +1251,7 @@
       "context_length": 200000,
       "created": 1740422110,
       "description": "Claude 3.7 Sonnet is an advanced large language model with improved reasoning, coding, and problem-solving capabilities. It introduces a hybrid reasoning approach, allowing users to choose between rapid responses and extended, step-by-step processing for complex tasks. The model demonstrates notable improvements in coding, particularly in front-end development and full-stack updates, and excels in agentic workflows, where it can autonomously navigate multi-step processes. \n\nClaude 3.7 Sonnet maintains performance parity with its predecessor in standard mode while offering an extended reasoning mode for enhanced accuracy in math, coding, and instruction-following tasks.\n\nRead more at the [blog post here](https://www.anthropic.com/news/claude-3-7-sonnet)",
+      "hugging_face_id": "",
       "id": "anthropic/claude-3.7-sonnet:thinking",
       "name": "Anthropic: Claude 3.7 Sonnet (thinking)",
       "per_request_limits": null,
@@ -1136,9 +1265,110 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
+        "max_completion_tokens": 64000
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Claude"
+      },
+      "context_length": 200000,
+      "created": 1747931245,
+      "description": "Claude Opus 4 is benchmarked as the world’s best coding model, at time of release, bringing sustained performance on complex, long-running tasks and agent workflows. It sets new benchmarks in software engineering, achieving leading results on SWE-bench (72.5%) and Terminal-bench (43.2%). Opus 4 supports extended, agentic workflows, handling thousands of task steps continuously for hours without degradation. \n\nRead more at the [blog post here](https://www.anthropic.com/news/claude-4)",
+      "hugging_face_id": "",
+      "id": "anthropic/claude-opus-4",
+      "name": "Anthropic: Claude Opus 4",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.000075",
+        "image": "0.024",
+        "input_cache_read": "0.0000015",
+        "input_cache_write": "0.00001875",
+        "internal_reasoning": "0",
+        "prompt": "0.000015",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "stop",
+        "reasoning",
+        "include_reasoning",
+        "tools",
+        "tool_choice"
+      ],
+      "top_provider": {
+        "context_length": 200000,
+        "is_moderated": true,
+        "max_completion_tokens": 32000
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Claude"
+      },
+      "context_length": 200000,
+      "created": 1747930371,
+      "description": "Claude Sonnet 4 significantly enhances the capabilities of its predecessor, Sonnet 3.7, excelling in both coding and reasoning tasks with improved precision and controllability. Achieving state-of-the-art performance on SWE-bench (72.7%), Sonnet 4 balances capability and computational efficiency, making it suitable for a broad range of applications from routine coding tasks to complex software development projects. Key enhancements include improved autonomous codebase navigation, reduced error rates in agent-driven workflows, and increased reliability in following intricate instructions. Sonnet 4 is optimized for practical everyday use, providing advanced reasoning capabilities while maintaining efficiency and responsiveness in diverse internal and external scenarios.\n\nRead more at the [blog post here](https://www.anthropic.com/news/claude-4)",
+      "hugging_face_id": "",
+      "id": "anthropic/claude-sonnet-4",
+      "name": "Anthropic: Claude Sonnet 4",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.000015",
+        "image": "0.0048",
+        "input_cache_read": "0.0000003",
+        "input_cache_write": "0.00000375",
+        "internal_reasoning": "0",
+        "prompt": "0.000003",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "stop",
+        "reasoning",
+        "include_reasoning",
+        "tools",
+        "tool_choice"
+      ],
+      "top_provider": {
+        "context_length": 200000,
+        "is_moderated": true,
         "max_completion_tokens": 64000
       }
     },
@@ -1157,6 +1387,7 @@
       "context_length": 200000,
       "created": 1700611200,
       "description": "Claude 2 delivers advancements in key capabilities for enterprises—including an industry-leading 200K token context window, significant reductions in rates of model hallucination, system prompts and a new beta feature: tool use.",
+      "hugging_face_id": null,
       "id": "anthropic/claude-2",
       "name": "Anthropic: Claude v2",
       "per_request_limits": null,
@@ -1168,6 +1399,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -1189,6 +1427,7 @@
       "context_length": 200000,
       "created": 1700611200,
       "description": "Claude 2 delivers advancements in key capabilities for enterprises—including an industry-leading 200K token context window, significant reductions in rates of model hallucination, system prompts and a new beta feature: tool use.",
+      "hugging_face_id": null,
       "id": "anthropic/claude-2:beta",
       "name": "Anthropic: Claude v2 (self-moderated)",
       "per_request_limits": null,
@@ -1200,6 +1439,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -1221,6 +1467,7 @@
       "context_length": 100000,
       "created": 1690502400,
       "description": "Anthropic's flagship model. Superior performance on tasks that require complex reasoning. Supports hundreds of pages of text.",
+      "hugging_face_id": null,
       "id": "anthropic/claude-2.0",
       "name": "Anthropic: Claude v2.0",
       "per_request_limits": null,
@@ -1232,6 +1479,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 100000,
         "is_moderated": true,
@@ -1253,6 +1507,7 @@
       "context_length": 100000,
       "created": 1690502400,
       "description": "Anthropic's flagship model. Superior performance on tasks that require complex reasoning. Supports hundreds of pages of text.",
+      "hugging_face_id": null,
       "id": "anthropic/claude-2.0:beta",
       "name": "Anthropic: Claude v2.0 (self-moderated)",
       "per_request_limits": null,
@@ -1264,6 +1519,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 100000,
         "is_moderated": false,
@@ -1285,6 +1547,7 @@
       "context_length": 200000,
       "created": 1700611200,
       "description": "Claude 2 delivers advancements in key capabilities for enterprises—including an industry-leading 200K token context window, significant reductions in rates of model hallucination, system prompts and a new beta feature: tool use.",
+      "hugging_face_id": null,
       "id": "anthropic/claude-2.1",
       "name": "Anthropic: Claude v2.1",
       "per_request_limits": null,
@@ -1296,6 +1559,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -1317,6 +1587,7 @@
       "context_length": 200000,
       "created": 1700611200,
       "description": "Claude 2 delivers advancements in key capabilities for enterprises—including an industry-leading 200K token context window, significant reductions in rates of model hallucination, system prompts and a new beta feature: tool use.",
+      "hugging_face_id": null,
       "id": "anthropic/claude-2.1:beta",
       "name": "Anthropic: Claude v2.1 (self-moderated)",
       "per_request_limits": null,
@@ -1328,10 +1599,342 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
         "max_completion_tokens": 4096
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1746470100,
+      "description": "Arcee Blitz is a 24 B‑parameter dense model distilled from DeepSeek and built on Mistral architecture for \"everyday\" chat. The distillation‑plus‑refinement pipeline trims compute while keeping DeepSeek‑style reasoning, so Blitz punches above its weight on MMLU, GSM‑8K and BBH compared with other mid‑size open models. With a default 128 k context window and competitive throughput, it serves as a cost‑efficient workhorse for summarization, brainstorming and light code help. Internally, Arcee uses Blitz as the default writer in Conductor pipelines when the heavier Virtuoso line is not required. Users therefore get near‑70 B quality at ~⅓ the latency and price. ",
+      "hugging_face_id": "arcee-ai/arcee-blitz",
+      "id": "arcee-ai/arcee-blitz",
+      "name": "Arcee AI: Arcee Blitz",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000075",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000045",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1746487869,
+      "description": "Caller Large is Arcee's specialist \"function‑calling\" SLM built to orchestrate external tools and APIs. Instead of maximizing next‑token accuracy, training focuses on structured JSON outputs, parameter extraction and multi‑step tool chains, making Caller a natural choice for retrieval‑augmented generation, robotic process automation or data‑pull chatbots. It incorporates a routing head that decides when (and how) to invoke a tool versus answering directly, reducing hallucinated calls. The model is already the backbone of Arcee Conductor's auto‑tool mode, where it parses user intent, emits clean function signatures and hands control back once the tool response is ready. Developers thus gain an OpenAI‑style function‑calling UX without handing requests to a frontier‑scale model. ",
+      "hugging_face_id": "",
+      "id": "arcee-ai/caller-large",
+      "name": "Arcee AI: Caller Large",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000085",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000055",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1746478663,
+      "description": "Coder‑Large is a 32 B‑parameter offspring of Qwen 2.5‑Instruct that has been further trained on permissively‑licensed GitHub, CodeSearchNet and synthetic bug‑fix corpora. It supports a 32k context window, enabling multi‑file refactoring or long diff review in a single call, and understands 30‑plus programming languages with special attention to TypeScript, Go and Terraform. Internal benchmarks show 5–8 pt gains over CodeLlama‑34 B‑Python on HumanEval and competitive BugFix scores thanks to a reinforcement pass that rewards compilable output. The model emits structured explanations alongside code blocks by default, making it suitable for educational tooling as well as production copilot scenarios. Cost‑wise, Together AI prices it well below proprietary incumbents, so teams can scale interactive coding without runaway spend. ",
+      "hugging_face_id": "",
+      "id": "arcee-ai/coder-large",
+      "name": "Arcee AI: Coder Large",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000008",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000005",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 131072,
+      "created": 1746481269,
+      "description": "Maestro Reasoning is Arcee's flagship analysis model: a 32 B‑parameter derivative of Qwen 2.5‑32 B tuned with DPO and chain‑of‑thought RL for step‑by‑step logic. Compared to the earlier 7 B preview, the production 32 B release widens the context window to 128 k tokens and doubles pass‑rate on MATH and GSM‑8K, while also lifting code completion accuracy. Its instruction style encourages structured \"thought → answer\" traces that can be parsed or hidden according to user preference. That transparency pairs well with audit‑focused industries like finance or healthcare where seeing the reasoning path matters. In Arcee Conductor, Maestro is automatically selected for complex, multi‑constraint queries that smaller SLMs bounce. ",
+      "hugging_face_id": "",
+      "id": "arcee-ai/maestro-reasoning",
+      "name": "Arcee AI: Maestro Reasoning",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000033",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000009",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": 32000
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 131072,
+      "created": 1746481552,
+      "description": "Spotlight is a 7‑billion‑parameter vision‑language model derived from Qwen 2.5‑VL and fine‑tuned by Arcee AI for tight image‑text grounding tasks. It offers a 32 k‑token context window, enabling rich multimodal conversations that combine lengthy documents with one or more images. Training emphasized fast inference on consumer GPUs while retaining strong captioning, visual‐question‑answering, and diagram‑analysis accuracy. As a result, Spotlight slots neatly into agent workflows where screenshots, charts or UI mock‑ups need to be interpreted on the fly. Early benchmarks show it matching or out‑scoring larger VLMs such as LLaVA‑1.6 13 B on popular VQA and POPE alignment tests. ",
+      "hugging_face_id": "",
+      "id": "arcee-ai/spotlight",
+      "name": "Arcee AI: Spotlight",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000018",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000018",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": 65537
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 131072,
+      "created": 1746478885,
+      "description": "Virtuoso‑Large is Arcee's top‑tier general‑purpose LLM at 72 B parameters, tuned to tackle cross‑domain reasoning, creative writing and enterprise QA. Unlike many 70 B peers, it retains the 128 k context inherited from Qwen 2.5, letting it ingest books, codebases or financial filings wholesale. Training blended DeepSeek R1 distillation, multi‑epoch supervised fine‑tuning and a final DPO/RLHF alignment stage, yielding strong performance on BIG‑Bench‑Hard, GSM‑8K and long‑context Needle‑In‑Haystack tests. Enterprises use Virtuoso‑Large as the \"fallback\" brain in Conductor pipelines when other SLMs flag low confidence. Despite its size, aggressive KV‑cache optimizations keep first‑token latency in the low‑second range on 8× H100 nodes, making it a practical production‑grade powerhouse.",
+      "hugging_face_id": "",
+      "id": "arcee-ai/virtuoso-large",
+      "name": "Arcee AI: Virtuoso Large",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000012",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000075",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": 64000
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 131072,
+      "created": 1746478434,
+      "description": "Virtuoso‑Medium‑v2 is a 32 B model distilled from DeepSeek‑v3 logits and merged back onto a Qwen 2.5 backbone, yielding a sharper, more factual successor to the original Virtuoso Medium. The team harvested ~1.1 B logit tokens and applied \"fusion‑merging\" plus DPO alignment, which pushed scores past Arcee‑Nova 2024 and many 40 B‑plus peers on MMLU‑Pro, MATH and HumanEval. With a 128 k context and aggressive quantization options (from BF16 down to 4‑bit GGUF), it balances capability with deployability on single‑GPU nodes. Typical use cases include enterprise chat assistants, technical writing aids and medium‑complexity code drafting where Virtuoso‑Large would be overkill. ",
+      "hugging_face_id": "arcee-ai/Virtuoso-Medium-v2",
+      "id": "arcee-ai/virtuoso-medium-v2",
+      "name": "Arcee AI: Virtuoso Medium V2",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000008",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000005",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": 32768
       }
     },
     {
@@ -1349,6 +1952,7 @@
       "context_length": 32768,
       "created": 1744555982,
       "description": "QwQ-32B-ArliAI-RpR-v1 is a 32B parameter model fine-tuned from Qwen/QwQ-32B using a curated creative writing and roleplay dataset originally developed for the RPMax series. It is designed to maintain coherence and reasoning across long multi-turn conversations by introducing explicit reasoning steps per dialogue turn, generated and refined using the base model itself.\n\nThe model was trained using RS-QLORA+ on 8K sequence lengths and supports up to 128K context windows (with practical performance around 32K). It is optimized for creative roleplay and dialogue generation, with an emphasis on minimizing cross-context repetition while preserving stylistic diversity.",
+      "hugging_face_id": "ArliAI/QwQ-32B-ArliAI-RpR-v1",
       "id": "arliai/qwq-32b-arliai-rpr-v1:free",
       "name": "ArliAI: QwQ 32B RpR v1 (free)",
       "per_request_limits": null,
@@ -1360,6 +1964,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -1381,6 +2002,7 @@
       "context_length": 2000000,
       "created": 1699401600,
       "description": "Your prompt will be processed by a meta-model and routed to one of dozens of models (see below), optimizing for the best possible output.\n\nTo see which model was used, visit [Activity](/activity), or read the `model` attribute of the response. Your response will be priced at the same rate as the routed model.\n\nThe meta-model is powered by [Not Diamond](https://docs.notdiamond.ai/docs/how-not-diamond-works). Learn more in our [docs](/docs/model-routing).\n\nRequests will be routed to the following models:\n- [openai/gpt-4o-2024-08-06](/openai/gpt-4o-2024-08-06)\n- [openai/gpt-4o-2024-05-13](/openai/gpt-4o-2024-05-13)\n- [openai/gpt-4o-mini-2024-07-18](/openai/gpt-4o-mini-2024-07-18)\n- [openai/chatgpt-4o-latest](/openai/chatgpt-4o-latest)\n- [openai/o1-preview-2024-09-12](/openai/o1-preview-2024-09-12)\n- [openai/o1-mini-2024-09-12](/openai/o1-mini-2024-09-12)\n- [anthropic/claude-3.5-sonnet](/anthropic/claude-3.5-sonnet)\n- [anthropic/claude-3.5-haiku](/anthropic/claude-3.5-haiku)\n- [anthropic/claude-3-opus](/anthropic/claude-3-opus)\n- [anthropic/claude-2.1](/anthropic/claude-2.1)\n- [google/gemini-pro-1.5](/google/gemini-pro-1.5)\n- [google/gemini-flash-1.5](/google/gemini-flash-1.5)\n- [mistralai/mistral-large-2407](/mistralai/mistral-large-2407)\n- [mistralai/mistral-nemo](/mistralai/mistral-nemo)\n- [deepseek/deepseek-r1](/deepseek/deepseek-r1)\n- [meta-llama/llama-3.1-70b-instruct](/meta-llama/llama-3.1-70b-instruct)\n- [meta-llama/llama-3.1-405b-instruct](/meta-llama/llama-3.1-405b-instruct)\n- [mistralai/mixtral-8x22b-instruct](/mistralai/mixtral-8x22b-instruct)\n- [cohere/command-r-plus](/cohere/command-r-plus)\n- [cohere/command-r](/cohere/command-r)",
+      "hugging_face_id": null,
       "id": "openrouter/auto",
       "name": "Auto Router",
       "per_request_limits": null,
@@ -1388,41 +2010,9 @@
         "completion": "-1",
         "prompt": "-1"
       },
+      "supported_parameters": [],
       "top_provider": {
         "context_length": null,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "instruct_type": null,
-        "modality": "text+image->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 32768,
-      "created": 1743020065,
-      "description": "UI-TARS 72B is an open-source multimodal AI model designed specifically for automating browser and desktop tasks through visual interaction and control. The model is built with a specialized vision architecture enabling accurate interpretation and manipulation of on-screen visual data. It supports automation tasks within web browsers as well as desktop applications, including Microsoft Office and VS Code.\n\nCore capabilities include intelligent screen detection, predictive action modeling, and efficient handling of repetitive interactions. UI-TARS employs supervised fine-tuning (SFT) tailored explicitly for computer control scenarios. It can be deployed locally or accessed via Hugging Face for demonstration purposes. Intended use cases encompass workflow automation, task scripting, and interactive desktop control applications.",
-      "id": "bytedance-research/ui-tars-72b:free",
-      "name": "Bytedance: UI-TARS 72B  (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 32768,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -1442,6 +2032,7 @@
       "context_length": 4096,
       "created": 1710374400,
       "description": "Command is an instruction-following conversational model that performs language tasks with high quality, more reliably and with a longer context than our base generative models.\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": null,
       "id": "cohere/command",
       "name": "Cohere: Command",
       "per_request_limits": null,
@@ -1453,6 +2044,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
@@ -1474,6 +2077,7 @@
       "context_length": 256000,
       "created": 1741894342,
       "description": "Command A is an open-weights 111B parameter model with a 256k context window focused on delivering great performance across agentic, multilingual, and coding use cases.\nCompared to other leading proprietary and open-weights models Command A delivers maximum performance with minimum hardware costs, excelling on business-critical agentic and multilingual tasks.",
+      "hugging_face_id": "CohereForAI/c4ai-command-a-03-2025",
       "id": "cohere/command-a",
       "name": "Cohere: Command A",
       "per_request_limits": null,
@@ -1485,6 +2089,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 256000,
         "is_moderated": false,
@@ -1506,6 +2122,7 @@
       "context_length": 128000,
       "created": 1710374400,
       "description": "Command-R is a 35B parameter model that performs conversational language tasks at a higher quality, more reliably, and with a longer context than previous models. It can be used for complex workflows like code generation, retrieval augmented generation (RAG), tool use, and agents.\n\nRead the launch post [here](https://txt.cohere.com/command-r/).\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": null,
       "id": "cohere/command-r",
       "name": "Cohere: Command R",
       "per_request_limits": null,
@@ -1517,6 +2134,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -1538,6 +2168,7 @@
       "context_length": 128000,
       "created": 1709341200,
       "description": "Command-R is a 35B parameter model that performs conversational language tasks at a higher quality, more reliably, and with a longer context than previous models. It can be used for complex workflows like code generation, retrieval augmented generation (RAG), tool use, and agents.\n\nRead the launch post [here](https://txt.cohere.com/command-r/).\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": null,
       "id": "cohere/command-r-03-2024",
       "name": "Cohere: Command R (03-2024)",
       "per_request_limits": null,
@@ -1549,6 +2180,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -1570,6 +2214,7 @@
       "context_length": 128000,
       "created": 1724976000,
       "description": "command-r-08-2024 is an update of the [Command R](/models/cohere/command-r) with improved performance for multilingual retrieval-augmented generation (RAG) and tool use. More broadly, it is better at math, code and reasoning and is competitive with the previous version of the larger Command R+ model.\n\nRead the launch post [here](https://docs.cohere.com/changelog/command-gets-refreshed).\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": null,
       "id": "cohere/command-r-08-2024",
       "name": "Cohere: Command R (08-2024)",
       "per_request_limits": null,
@@ -1581,6 +2226,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -1602,6 +2260,7 @@
       "context_length": 128000,
       "created": 1712188800,
       "description": "Command R+ is a new, 104B-parameter LLM from Cohere. It's useful for roleplay, general consumer usecases, and Retrieval Augmented Generation (RAG).\n\nIt offers multilingual support for ten key languages to facilitate global business operations. See benchmarks and the launch post [here](https://txt.cohere.com/command-r-plus-microsoft-azure/).\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": null,
       "id": "cohere/command-r-plus",
       "name": "Cohere: Command R+",
       "per_request_limits": null,
@@ -1613,6 +2272,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -1634,6 +2306,7 @@
       "context_length": 128000,
       "created": 1712016000,
       "description": "Command R+ is a new, 104B-parameter LLM from Cohere. It's useful for roleplay, general consumer usecases, and Retrieval Augmented Generation (RAG).\n\nIt offers multilingual support for ten key languages to facilitate global business operations. See benchmarks and the launch post [here](https://txt.cohere.com/command-r-plus-microsoft-azure/).\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": null,
       "id": "cohere/command-r-plus-04-2024",
       "name": "Cohere: Command R+ (04-2024)",
       "per_request_limits": null,
@@ -1645,6 +2318,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -1666,6 +2352,7 @@
       "context_length": 128000,
       "created": 1724976000,
       "description": "command-r-plus-08-2024 is an update of the [Command R+](/models/cohere/command-r-plus) with roughly 50% higher throughput and 25% lower latencies as compared to the previous Command R+ version, while keeping the hardware footprint the same.\n\nRead the launch post [here](https://docs.cohere.com/changelog/command-gets-refreshed).\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": null,
       "id": "cohere/command-r-plus-08-2024",
       "name": "Cohere: Command R+ (08-2024)",
       "per_request_limits": null,
@@ -1677,6 +2364,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -1698,6 +2398,7 @@
       "context_length": 128000,
       "created": 1734158152,
       "description": "Command R7B (12-2024) is a small, fast update of the Command R+ model, delivered in December 2024. It excels at RAG, tool use, agents, and similar tasks requiring complex reasoning and multiple steps.\n\nUse of this model is subject to Cohere's [Usage Policy](https://docs.cohere.com/docs/usage-policy) and [SaaS Agreement](https://cohere.com/saas-agreement).",
+      "hugging_face_id": "",
       "id": "cohere/command-r7b-12-2024",
       "name": "Cohere: Command R7B (12-2024)",
       "per_request_limits": null,
@@ -1709,10 +2410,163 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
         "max_completion_tokens": 4000
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 128000,
+      "created": 1715644800,
+      "description": "DeepSeek-Coder-V2, an open-source Mixture-of-Experts (MoE) code language model. It is further pre-trained from an intermediate checkpoint of DeepSeek-V2 with additional 6 trillion tokens.\n\nThe original V1 model was trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese. It was pre-trained on project-level code corpus by employing a extra fill-in-the-blank task.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-Coder-V2-Instruct",
+      "id": "deepseek/deepseek-coder",
+      "name": "DeepSeek-Coder-V2",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000012",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000004",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 128000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "DeepSeek"
+      },
+      "context_length": 131072,
+      "created": 1746013094,
+      "description": "DeepSeek Prover V2 is a 671B parameter model, speculated to be geared towards logic and mathematics. Likely an upgrade from [DeepSeek-Prover-V1.5](https://huggingface.co/deepseek-ai/DeepSeek-Prover-V1.5-RL) Not much is known about the model yet, as DeepSeek released it on Hugging Face without an announcement or description.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-Prover-V2-671B",
+      "id": "deepseek/deepseek-prover-v2",
+      "name": "DeepSeek: DeepSeek Prover V2",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000218",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000005",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "response_format"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "DeepSeek"
+      },
+      "context_length": 163840,
+      "created": 1746013094,
+      "description": "DeepSeek Prover V2 is a 671B parameter model, speculated to be geared towards logic and mathematics. Likely an upgrade from [DeepSeek-Prover-V1.5](https://huggingface.co/deepseek-ai/DeepSeek-Prover-V1.5-RL) Not much is known about the model yet, as DeepSeek released it on Hugging Face without an announcement or description.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-Prover-V2-671B",
+      "id": "deepseek/deepseek-prover-v2:free",
+      "name": "DeepSeek: DeepSeek Prover V2 (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 163840,
+        "is_moderated": false,
+        "max_completion_tokens": null
       }
     },
     {
@@ -1727,9 +2581,10 @@
         ],
         "tokenizer": "Other"
       },
-      "context_length": 163840,
+      "context_length": 128000,
       "created": 1741297434,
       "description": "DeepSeek-R1-Zero is a model trained via large-scale reinforcement learning (RL) without supervised fine-tuning (SFT) as a preliminary step. It's 671B parameters in size, with 37B active in an inference pass.\n\nIt demonstrates remarkable performance on reasoning. With RL, DeepSeek-R1-Zero naturally emerged with numerous powerful and interesting reasoning behaviors.\n\nDeepSeek-R1-Zero encounters challenges such as endless repetition, poor readability, and language mixing. See [DeepSeek R1](/deepseek/deepseek-r1) for the SFT model.\n\n",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Zero",
       "id": "deepseek/deepseek-r1-zero:free",
       "name": "DeepSeek: DeepSeek R1 Zero (free)",
       "per_request_limits": null,
@@ -1741,8 +2596,25 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 163840,
+        "context_length": 128000,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -1762,6 +2634,7 @@
       "context_length": 163840,
       "created": 1735241320,
       "description": "DeepSeek-V3 is the latest model from the DeepSeek team, building upon the instruction following and coding abilities of the previous versions. Pre-trained on nearly 15 trillion tokens, the reported evaluations reveal that the model outperforms other open-source models and rivals leading closed-source models.\n\nFor model details, please visit [the DeepSeek-V3 repo](https://github.com/deepseek-ai/DeepSeek-V3) for more information, or see the [launch announcement](https://api-docs.deepseek.com/news/news1226).",
+      "hugging_face_id": "deepseek-ai/DeepSeek-V3",
       "id": "deepseek/deepseek-chat",
       "name": "DeepSeek: DeepSeek V3",
       "per_request_limits": null,
@@ -1773,6 +2646,25 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "tools",
+        "tool_choice",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 163840,
         "is_moderated": false,
@@ -1794,6 +2686,7 @@
       "context_length": 163840,
       "created": 1735241320,
       "description": "DeepSeek-V3 is the latest model from the DeepSeek team, building upon the instruction following and coding abilities of the previous versions. Pre-trained on nearly 15 trillion tokens, the reported evaluations reveal that the model outperforms other open-source models and rivals leading closed-source models.\n\nFor model details, please visit [the DeepSeek-V3 repo](https://github.com/deepseek-ai/DeepSeek-V3) for more information, or see the [launch announcement](https://api-docs.deepseek.com/news/news1226).",
+      "hugging_face_id": "deepseek-ai/DeepSeek-V3",
       "id": "deepseek/deepseek-chat:free",
       "name": "DeepSeek: DeepSeek V3 (free)",
       "per_request_limits": null,
@@ -1805,6 +2698,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 163840,
         "is_moderated": false,
@@ -1823,25 +2732,44 @@
         ],
         "tokenizer": "DeepSeek"
       },
-      "context_length": 64000,
+      "context_length": 163840,
       "created": 1742824755,
       "description": "DeepSeek V3, a 685B-parameter, mixture-of-experts model, is the latest iteration of the flagship chat model family from the DeepSeek team.\n\nIt succeeds the [DeepSeek V3](/deepseek/deepseek-chat-v3) model and performs really well on a variety of tasks.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-V3-0324",
       "id": "deepseek/deepseek-chat-v3-0324",
       "name": "DeepSeek: DeepSeek V3 0324",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000011",
+        "completion": "0.00000088",
         "image": "0",
-        "input_cache_read": "0.00000007",
         "internal_reasoning": "0",
-        "prompt": "0.00000027",
+        "prompt": "0.0000003",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "top_k",
+        "stop",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "min_p"
+      ],
       "top_provider": {
-        "context_length": 64000,
+        "context_length": 163840,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": null
       }
     },
     {
@@ -1859,6 +2787,7 @@
       "context_length": 163840,
       "created": 1742824755,
       "description": "DeepSeek V3, a 685B-parameter, mixture-of-experts model, is the latest iteration of the flagship chat model family from the DeepSeek team.\n\nIt succeeds the [DeepSeek V3](/deepseek/deepseek-chat-v3) model and performs really well on a variety of tasks.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-V3-0324",
       "id": "deepseek/deepseek-chat-v3-0324:free",
       "name": "DeepSeek: DeepSeek V3 0324 (free)",
       "per_request_limits": null,
@@ -1870,6 +2799,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 163840,
         "is_moderated": false,
@@ -1891,6 +2836,7 @@
       "context_length": 163840,
       "created": 1743272023,
       "description": "Note that this is a base model mostly meant for testing, you need to provide detailed prompts for the model to return useful responses. \n\nDeepSeek-V3 Base is a 671B parameter open Mixture-of-Experts (MoE) language model with 37B active parameters per forward pass and a context length of 128K tokens. Trained on 14.8T tokens using FP8 mixed precision, it achieves high training efficiency and stability, with strong performance across language, reasoning, math, and coding tasks. \n\nDeepSeek-V3 Base is the pre-trained model behind [DeepSeek V3](/deepseek/deepseek-chat-v3)",
+      "hugging_face_id": "deepseek-ai/Deepseek-v3-base",
       "id": "deepseek/deepseek-v3-base:free",
       "name": "DeepSeek: DeepSeek V3 Base (free)",
       "per_request_limits": null,
@@ -1902,42 +2848,25 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 163840,
         "is_moderated": false,
         "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "deepseek-r1",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek"
-      },
-      "context_length": 128000,
-      "created": 1737381095,
-      "description": "DeepSeek R1 is here: Performance on par with [OpenAI o1](/openai/o1), but open-sourced and with fully open reasoning tokens. It's 671B parameters in size, with 37B active in an inference pass.\n\nFully open-source model & [technical report](https://api-docs.deepseek.com/news/news250120).\n\nMIT licensed: Distill & commercialize freely!",
-      "id": "deepseek/deepseek-r1",
-      "name": "DeepSeek: R1",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000003",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.0000005",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "is_moderated": false,
-        "max_completion_tokens": 32768
       }
     },
     {
@@ -1955,6 +2884,61 @@
       "context_length": 163840,
       "created": 1737381095,
       "description": "DeepSeek R1 is here: Performance on par with [OpenAI o1](/openai/o1), but open-sourced and with fully open reasoning tokens. It's 671B parameters in size, with 37B active in an inference pass.\n\nFully open-source model & [technical report](https://api-docs.deepseek.com/news/news250120).\n\nMIT licensed: Distill & commercialize freely!",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1",
+      "id": "deepseek/deepseek-r1",
+      "name": "DeepSeek: R1",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000218",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000005",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "repetition_penalty",
+        "response_format",
+        "structured_outputs",
+        "min_p",
+        "tools",
+        "tool_choice"
+      ],
+      "top_provider": {
+        "context_length": 163840,
+        "is_moderated": false,
+        "max_completion_tokens": 163840
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "deepseek-r1",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "DeepSeek"
+      },
+      "context_length": 163840,
+      "created": 1737381095,
+      "description": "DeepSeek R1 is here: Performance on par with [OpenAI o1](/openai/o1), but open-sourced and with fully open reasoning tokens. It's 671B parameters in size, with 37B active in an inference pass.\n\nFully open-source model & [technical report](https://api-docs.deepseek.com/news/news250120).\n\nMIT licensed: Distill & commercialize freely!",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1",
       "id": "deepseek/deepseek-r1:free",
       "name": "DeepSeek: R1 (free)",
       "per_request_limits": null,
@@ -1966,6 +2950,20 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "reasoning",
+        "include_reasoning",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "top_a",
+        "logprobs"
+      ],
       "top_provider": {
         "context_length": 163840,
         "is_moderated": false,
@@ -1984,9 +2982,10 @@
         ],
         "tokenizer": "Llama3"
       },
-      "context_length": 128000,
+      "context_length": 131072,
       "created": 1737663169,
       "description": "DeepSeek R1 Distill Llama 70B is a distilled large language model based on [Llama-3.3-70B-Instruct](/meta-llama/llama-3.3-70b-instruct), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). The model combines advanced distillation techniques to achieve high performance across multiple benchmarks, including:\n\n- AIME 2024 pass@1: 70.0\n- MATH-500 pass@1: 94.5\n- CodeForces Rating: 1633\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
       "id": "deepseek/deepseek-r1-distill-llama-70b",
       "name": "DeepSeek: R1 Distill Llama 70B",
       "per_request_limits": null,
@@ -1998,8 +2997,29 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "top_k",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "min_p",
+        "repetition_penalty",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 131072,
         "is_moderated": false,
         "max_completion_tokens": 16384
       }
@@ -2016,9 +3036,10 @@
         ],
         "tokenizer": "Llama3"
       },
-      "context_length": 128000,
+      "context_length": 8192,
       "created": 1737663169,
       "description": "DeepSeek R1 Distill Llama 70B is a distilled large language model based on [Llama-3.3-70B-Instruct](/meta-llama/llama-3.3-70b-instruct), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). The model combines advanced distillation techniques to achieve high performance across multiple benchmarks, including:\n\n- AIME 2024 pass@1: 70.0\n- MATH-500 pass@1: 94.5\n- CodeForces Rating: 1633\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
       "id": "deepseek/deepseek-r1-distill-llama-70b:free",
       "name": "DeepSeek: R1 Distill Llama 70B (free)",
       "per_request_limits": null,
@@ -2030,10 +3051,28 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 8192,
         "is_moderated": false,
-        "max_completion_tokens": null
+        "max_completion_tokens": 4096
       }
     },
     {
@@ -2051,6 +3090,7 @@
       "context_length": 32000,
       "created": 1738937718,
       "description": "DeepSeek R1 Distill Llama 8B is a distilled large language model based on [Llama-3.1-8B-Instruct](/meta-llama/llama-3.1-8b-instruct), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). The model combines advanced distillation techniques to achieve high performance across multiple benchmarks, including:\n\n- AIME 2024 pass@1: 50.4\n- MATH-500 pass@1: 89.1\n- CodeForces Rating: 1205\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.\n\nHugging Face: \n- [Llama-3.1-8B](https://huggingface.co/meta-llama/Llama-3.1-8B) \n- [DeepSeek-R1-Distill-Llama-8B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B)   |",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
       "id": "deepseek/deepseek-r1-distill-llama-8b",
       "name": "DeepSeek: R1 Distill Llama 8B",
       "per_request_limits": null,
@@ -2062,6 +3102,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 32000,
         "is_moderated": false,
@@ -2083,6 +3138,7 @@
       "context_length": 131072,
       "created": 1738328067,
       "description": "DeepSeek R1 Distill Qwen 1.5B is a distilled large language model based on  [Qwen 2.5 Math 1.5B](https://huggingface.co/Qwen/Qwen2.5-Math-1.5B), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). It's a very small and efficient model which outperforms [GPT 4o 0513](/openai/gpt-4o-2024-05-13) on Math Benchmarks.\n\nOther benchmark results include:\n\n- AIME 2024 pass@1: 28.9\n- AIME 2024 cons@64: 52.7\n- MATH-500 pass@1: 83.9\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
       "id": "deepseek/deepseek-r1-distill-qwen-1.5b",
       "name": "DeepSeek: R1 Distill Qwen 1.5B",
       "per_request_limits": null,
@@ -2094,6 +3150,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -2115,6 +3186,7 @@
       "context_length": 64000,
       "created": 1738193940,
       "description": "DeepSeek R1 Distill Qwen 14B is a distilled large language model based on [Qwen 2.5 14B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). It outperforms OpenAI's o1-mini across various benchmarks, achieving new state-of-the-art results for dense models.\n\nOther benchmark results include:\n\n- AIME 2024 pass@1: 69.7\n- MATH-500 pass@1: 93.9\n- CodeForces Rating: 1481\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "id": "deepseek/deepseek-r1-distill-qwen-14b",
       "name": "DeepSeek: R1 Distill Qwen 14B",
       "per_request_limits": null,
@@ -2126,6 +3198,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 64000,
         "is_moderated": false,
@@ -2147,6 +3235,7 @@
       "context_length": 64000,
       "created": 1738193940,
       "description": "DeepSeek R1 Distill Qwen 14B is a distilled large language model based on [Qwen 2.5 14B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). It outperforms OpenAI's o1-mini across various benchmarks, achieving new state-of-the-art results for dense models.\n\nOther benchmark results include:\n\n- AIME 2024 pass@1: 69.7\n- MATH-500 pass@1: 93.9\n- CodeForces Rating: 1481\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
       "id": "deepseek/deepseek-r1-distill-qwen-14b:free",
       "name": "DeepSeek: R1 Distill Qwen 14B (free)",
       "per_request_limits": null,
@@ -2158,6 +3247,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 64000,
         "is_moderated": false,
@@ -2179,6 +3285,7 @@
       "context_length": 131072,
       "created": 1738194830,
       "description": "DeepSeek R1 Distill Qwen 32B is a distilled large language model based on [Qwen 2.5 32B](https://huggingface.co/Qwen/Qwen2.5-32B), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). It outperforms OpenAI's o1-mini across various benchmarks, achieving new state-of-the-art results for dense models.\n\nOther benchmark results include:\n\n- AIME 2024 pass@1: 72.6\n- MATH-500 pass@1: 94.3\n- CodeForces Rating: 1691\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
       "id": "deepseek/deepseek-r1-distill-qwen-32b",
       "name": "DeepSeek: R1 Distill Qwen 32B",
       "per_request_limits": null,
@@ -2190,10 +3297,26 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -2211,6 +3334,7 @@
       "context_length": 16000,
       "created": 1738194830,
       "description": "DeepSeek R1 Distill Qwen 32B is a distilled large language model based on [Qwen 2.5 32B](https://huggingface.co/Qwen/Qwen2.5-32B), using outputs from [DeepSeek R1](/deepseek/deepseek-r1). It outperforms OpenAI's o1-mini across various benchmarks, achieving new state-of-the-art results for dense models.\n\nOther benchmark results include:\n\n- AIME 2024 pass@1: 72.6\n- MATH-500 pass@1: 94.3\n- CodeForces Rating: 1691\n\nThe model leverages fine-tuning from DeepSeek R1's outputs, enabling competitive performance comparable to larger frontier models.",
+      "hugging_face_id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
       "id": "deepseek/deepseek-r1-distill-qwen-32b:free",
       "name": "DeepSeek: R1 Distill Qwen 32B (free)",
       "per_request_limits": null,
@@ -2222,6 +3346,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning"
+      ],
       "top_provider": {
         "context_length": 16000,
         "is_moderated": false,
@@ -2240,41 +3371,10 @@
         ],
         "tokenizer": "Mistral"
       },
-      "context_length": 32768,
-      "created": 1703116800,
-      "description": "This is a 16k context fine-tune of [Mixtral-8x7b](/models/mistralai/mixtral-8x7b). It excels in coding tasks due to extensive training with coding data and is known for its obedience, although it lacks DPO tuning.\n\nThe model is uncensored and is stripped of alignment and bias. It requires an external alignment layer for ethical use. Users are cautioned to use this highly compliant model responsibly, as detailed in a blog post about uncensored models at [erichartford.com/uncensored-models](https://erichartford.com/uncensored-models).\n\n#moe #uncensored",
-      "id": "cognitivecomputations/dolphin-mixtral-8x7b",
-      "name": "Dolphin 2.6 Mixtral 8x7B 🐬",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000005",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.0000005",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "chatml",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral"
-      },
       "context_length": 16000,
       "created": 1717804800,
       "description": "Dolphin 2.9 is designed for instruction following, conversational, and coding. This model is a finetune of [Mixtral 8x22B Instruct](/models/mistralai/mixtral-8x22b-instruct). It features a 64k context length and was fine-tuned with a 16k sequence length using ChatML templates.\n\nThis model is a successor to [Dolphin Mixtral 8x7B](/models/cognitivecomputations/dolphin-mixtral-8x7b).\n\nThe model is uncensored and is stripped of alignment and bias. It requires an external alignment layer for ethical use. Users are cautioned to use this highly compliant model responsibly, as detailed in a blog post about uncensored models at [erichartford.com/uncensored-models](https://erichartford.com/uncensored-models).\n\n#moe #uncensored",
+      "hugging_face_id": "cognitivecomputations/dolphin-2.9.2-mixtral-8x22b",
       "id": "cognitivecomputations/dolphin-mixtral-8x22b",
       "name": "Dolphin 2.9.2 Mixtral 8x22B 🐬",
       "per_request_limits": null,
@@ -2286,10 +3386,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 16000,
         "is_moderated": false,
-        "max_completion_tokens": null
+        "max_completion_tokens": 8192
       }
     },
     {
@@ -2307,6 +3420,7 @@
       "context_length": 32768,
       "created": 1739462019,
       "description": "Dolphin 3.0 is the next generation of the Dolphin series of instruct-tuned models.  Designed to be the ultimate general purpose local model, enabling coding, math, agentic, function calling, and general use cases.\n\nDolphin aims to be a general purpose instruct model, similar to the models behind ChatGPT, Claude, Gemini. \n\nPart of the [Dolphin 3.0 Collection](https://huggingface.co/collections/cognitivecomputations/dolphin-30-677ab47f73d7ff66743979a3) Curated and trained by [Eric Hartford](https://huggingface.co/ehartford), [Ben Gitter](https://huggingface.co/bigstorm), [BlouseJury](https://huggingface.co/BlouseJury) and [Cognitive Computations](https://huggingface.co/cognitivecomputations)",
+      "hugging_face_id": "cognitivecomputations/Dolphin3.0-Mistral-24B",
       "id": "cognitivecomputations/dolphin3.0-mistral-24b:free",
       "name": "Dolphin3.0 Mistral 24B (free)",
       "per_request_limits": null,
@@ -2318,6 +3432,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -2339,6 +3468,7 @@
       "context_length": 32768,
       "created": 1739462498,
       "description": "Dolphin 3.0 R1 is the next generation of the Dolphin series of instruct-tuned models.  Designed to be the ultimate general purpose local model, enabling coding, math, agentic, function calling, and general use cases.\n\nThe R1 version has been trained for 3 epochs to reason using 800k reasoning traces from the Dolphin-R1 dataset.\n\nDolphin aims to be a general purpose reasoning instruct model, similar to the models behind ChatGPT, Claude, Gemini.\n\nPart of the [Dolphin 3.0 Collection](https://huggingface.co/collections/cognitivecomputations/dolphin-30-677ab47f73d7ff66743979a3) Curated and trained by [Eric Hartford](https://huggingface.co/ehartford), [Ben Gitter](https://huggingface.co/bigstorm), [BlouseJury](https://huggingface.co/BlouseJury) and [Cognitive Computations](https://huggingface.co/cognitivecomputations)",
+      "hugging_face_id": "cognitivecomputations/Dolphin3.0-R1-Mistral-24B",
       "id": "cognitivecomputations/dolphin3.0-r1-mistral-24b:free",
       "name": "Dolphin3.0 R1 Mistral 24B (free)",
       "per_request_limits": null,
@@ -2350,6 +3480,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -2361,7 +3508,7 @@
         "input_modalities": [
           "text"
         ],
-        "instruct_type": null,
+        "instruct_type": "code-llama",
         "modality": "text->text",
         "output_modalities": [
           "text"
@@ -2371,6 +3518,7 @@
       "context_length": 4096,
       "created": 1744643225,
       "description": "Llemma 7B is a language model for mathematics. It was initialized with Code Llama 7B weights, and trained on the Proof-Pile-2 for 200B tokens. Llemma models are particularly strong at chain-of-thought mathematical reasoning and using computational tools for mathematics, such as Python and formal theorem provers.",
+      "hugging_face_id": "EleutherAI/llemma_7b",
       "id": "eleutherai/llemma_7b",
       "name": "EleutherAI: Llemma 7b",
       "per_request_limits": null,
@@ -2382,6 +3530,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
@@ -2403,6 +3563,7 @@
       "context_length": 16384,
       "created": 1734377303,
       "description": "EVA Llama 3.33 70b is a roleplay and storywriting specialist model. It is a full-parameter finetune of [Llama-3.3-70B-Instruct](https://openrouter.ai/meta-llama/llama-3.3-70b-instruct) on mixture of synthetic and natural data.\n\nIt uses Celeste 70B 0.1 data mixture, greatly expanding it to improve versatility, creativity and \"flavor\" of the resulting model\n\nThis model was built with Llama by Meta.\n",
+      "hugging_face_id": "EVA-UNIT-01/EVA-LLaMA-3.33-70B-v0.1",
       "id": "eva-unit-01/eva-llama-3.33-70b",
       "name": "EVA Llama 3.33 70B",
       "per_request_limits": null,
@@ -2414,6 +3575,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -2435,6 +3608,7 @@
       "context_length": 16384,
       "created": 1731104847,
       "description": "EVA Qwen2.5 32B is a roleplaying/storywriting specialist model. It's a full-parameter finetune of Qwen2.5-32B on mixture of synthetic and natural data.\n\nIt uses Celeste 70B 0.1 data mixture, greatly expanding it to improve versatility, creativity and \"flavor\" of the resulting model.",
+      "hugging_face_id": "EVA-UNIT-01/EVA-Qwen2.5-32B-v0.2",
       "id": "eva-unit-01/eva-qwen-2.5-32b",
       "name": "EVA Qwen2.5 32B",
       "per_request_limits": null,
@@ -2446,6 +3620,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -2464,24 +3650,37 @@
         ],
         "tokenizer": "Qwen"
       },
-      "context_length": 131072,
+      "context_length": 16384,
       "created": 1732210606,
       "description": "EVA Qwen2.5 72B is a roleplay and storywriting specialist model. It's a full-parameter finetune of Qwen2.5-72B on mixture of synthetic and natural data.\n\nIt uses Celeste 70B 0.1 data mixture, greatly expanding it to improve versatility, creativity and \"flavor\" of the resulting model.",
+      "hugging_face_id": "EVA-UNIT-01/EVA-Qwen2.5-72B-v0.1",
       "id": "eva-unit-01/eva-qwen-2.5-72b",
       "name": "EVA Qwen2.5 72B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000012",
+        "completion": "0.000006",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000009",
+        "prompt": "0.000004",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
-        "context_length": 131072,
+        "context_length": 16384,
         "is_moderated": false,
-        "max_completion_tokens": 131072
+        "max_completion_tokens": 4096
       }
     },
     {
@@ -2499,6 +3698,7 @@
       "context_length": 4096,
       "created": 1713657600,
       "description": "Creative writing model, routed with permission. It's fast, it keeps the conversation going, and it stays in character.\n\nIf you submit a raw prompt, you can use Alpaca or Vicuna formats.",
+      "hugging_face_id": "Sao10K/Fimbulvetr-11B-v2",
       "id": "sao10k/fimbulvetr-11b-v2",
       "name": "Fimbulvetr 11B v2",
       "per_request_limits": null,
@@ -2510,6 +3710,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
@@ -2531,17 +3743,32 @@
       "context_length": 6144,
       "created": 1699574400,
       "description": "A large LLM created by combining two fine-tuned Llama 70B models into one 120B model. Combines Xwin and Euryale.\n\nCredits to\n- [@chargoddard](https://huggingface.co/chargoddard) for developing the framework used to merge the model - [mergekit](https://github.com/cg123/mergekit).\n- [@Undi95](https://huggingface.co/Undi95) for helping with the merge ratios.\n\n#merge",
+      "hugging_face_id": "alpindale/goliath-120b",
       "id": "alpindale/goliath-120b",
       "name": "Goliath 120B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000009375",
+        "completion": "0.0000125",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000065625",
+        "prompt": "0.00001",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 6144,
         "is_moderated": false,
@@ -2564,6 +3791,7 @@
       "context_length": 1000000,
       "created": 1715644800,
       "description": "Gemini 1.5 Flash is a foundation model that performs well at a variety of multimodal tasks such as visual understanding, classification, summarization, and creating content from image, audio and video. It's adept at processing visual and text inputs such as photographs, documents, infographics, and screenshots.\n\nGemini 1.5 Flash is designed for high-volume, high-frequency tasks where cost and latency matter. On most common tasks, Flash achieves comparable quality to other Gemini Pro models at a significantly reduced cost. Flash is well-suited for applications like chat assistants and on-demand content generation where speed and scale matter.\n\nUsage of Gemini is subject to Google's [Gemini Terms of Use](https://ai.google.dev/terms).\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "google/gemini-flash-1.5",
       "name": "Google: Gemini 1.5 Flash ",
       "per_request_limits": null,
@@ -2577,6 +3805,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "tools",
+        "tool_choice",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 1000000,
         "is_moderated": false,
@@ -2599,6 +3840,7 @@
       "context_length": 1000000,
       "created": 1727913600,
       "description": "Gemini Flash 1.5 8B is optimized for speed and efficiency, offering enhanced performance in small prompt tasks like chat, transcription, and translation. With reduced latency, it is highly effective for real-time and large-scale operations. This model focuses on cost-effective solutions while maintaining high-quality results.\n\n[Click here to learn more about this model](https://developers.googleblog.com/en/gemini-15-flash-8b-is-now-generally-available-for-use/).\n\nUsage of Gemini is subject to Google's [Gemini Terms of Use](https://ai.google.dev/terms).",
+      "hugging_face_id": null,
       "id": "google/gemini-flash-1.5-8b",
       "name": "Google: Gemini 1.5 Flash 8B",
       "per_request_limits": null,
@@ -2612,39 +3854,19 @@
         "request": "0",
         "web_search": "0"
       },
-      "top_provider": {
-        "context_length": 1000000,
-        "is_moderated": false,
-        "max_completion_tokens": 8192
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "instruct_type": null,
-        "modality": "text+image->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Gemini"
-      },
-      "context_length": 1000000,
-      "created": 1724803200,
-      "description": "Gemini Flash 1.5 8B Experimental is an experimental, 8B parameter version of the [Gemini Flash 1.5](/models/google/gemini-flash-1.5) model.\n\nUsage of Gemini is subject to Google's [Gemini Terms of Use](https://ai.google.dev/terms).\n\n#multimodal\n\nNote: This model is currently experimental and not suitable for production use-cases, and may be heavily rate-limited.",
-      "id": "google/gemini-flash-1.5-8b-exp",
-      "name": "Google: Gemini 1.5 Flash 8B Experimental",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "tools",
+        "tool_choice",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 1000000,
         "is_moderated": false,
@@ -2667,6 +3889,7 @@
       "context_length": 2000000,
       "created": 1712620800,
       "description": "Google's latest multimodal model, supports image and video[0] in text or chat prompts.\n\nOptimized for language tasks including:\n\n- Code generation\n- Text generation\n- Text editing\n- Problem solving\n- Recommendations\n- Information extraction\n- Data extraction or generation\n- AI agents\n\nUsage of Gemini is subject to Google's [Gemini Terms of Use](https://ai.google.dev/terms).\n\n* [0]: Video input is not available through OpenRouter at this time.",
+      "hugging_face_id": null,
       "id": "google/gemini-pro-1.5",
       "name": "Google: Gemini 1.5 Pro",
       "per_request_limits": null,
@@ -2678,6 +3901,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "tools",
+        "tool_choice",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 2000000,
         "is_moderated": false,
@@ -2688,7 +3924,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -2697,22 +3934,38 @@
         ],
         "tokenizer": "Gemini"
       },
-      "context_length": 1000000,
+      "context_length": 1048576,
       "created": 1738769413,
       "description": "Gemini Flash 2.0 offers a significantly faster time to first token (TTFT) compared to [Gemini Flash 1.5](/google/gemini-flash-1.5), while maintaining quality on par with larger models like [Gemini Pro 1.5](/google/gemini-pro-1.5). It introduces notable enhancements in multimodal understanding, coding capabilities, complex instruction following, and function calling. These advancements come together to deliver more seamless and robust agentic experiences.",
+      "hugging_face_id": "",
       "id": "google/gemini-2.0-flash-001",
       "name": "Google: Gemini 2.0 Flash",
       "per_request_limits": null,
       "pricing": {
         "completion": "0.0000004",
         "image": "0.0000258",
+        "input_cache_read": "0.000000025",
+        "input_cache_write": "0.0000001833",
         "internal_reasoning": "0",
         "prompt": "0.0000001",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
-        "context_length": 1000000,
+        "context_length": 1048576,
         "is_moderated": false,
         "max_completion_tokens": 8192
       }
@@ -2733,6 +3986,7 @@
       "context_length": 1048576,
       "created": 1733937523,
       "description": "Gemini Flash 2.0 offers a significantly faster time to first token (TTFT) compared to [Gemini Flash 1.5](/google/gemini-flash-1.5), while maintaining quality on par with larger models like [Gemini Pro 1.5](/google/gemini-pro-1.5). It introduces notable enhancements in multimodal understanding, coding capabilities, complex instruction following, and function calling. These advancements come together to deliver more seamless and robust agentic experiences.",
+      "hugging_face_id": "",
       "id": "google/gemini-2.0-flash-exp:free",
       "name": "Google: Gemini 2.0 Flash Experimental (free)",
       "per_request_limits": null,
@@ -2744,6 +3998,12 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 1048576,
         "is_moderated": false,
@@ -2754,7 +4014,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -2766,6 +4027,7 @@
       "context_length": 1048576,
       "created": 1740506212,
       "description": "Gemini 2.0 Flash Lite offers a significantly faster time to first token (TTFT) compared to [Gemini Flash 1.5](/google/gemini-flash-1.5), while maintaining quality on par with larger models like [Gemini Pro 1.5](/google/gemini-pro-1.5), all at extremely economical token prices.",
+      "hugging_face_id": "",
       "id": "google/gemini-2.0-flash-lite-001",
       "name": "Google: Gemini 2.0 Flash Lite",
       "per_request_limits": null,
@@ -2777,6 +4039,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 1048576,
         "is_moderated": false,
@@ -2786,41 +4061,9 @@
     {
       "architecture": {
         "input_modalities": [
+          "image",
           "text",
-          "image"
-        ],
-        "instruct_type": null,
-        "modality": "text+image->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Gemini"
-      },
-      "context_length": 40000,
-      "created": 1734650026,
-      "description": "Gemini 2.0 Flash Thinking Mode is an experimental model that's trained to generate the \"thinking process\" the model goes through as part of its response. As a result, Thinking Mode is capable of stronger reasoning capabilities in its responses than the [base Gemini 2.0 Flash model](/google/gemini-2.0-flash-exp).",
-      "id": "google/gemini-2.0-flash-thinking-exp-1219:free",
-      "name": "Google: Gemini 2.0 Flash Thinking Experimental (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 40000,
-        "is_moderated": false,
-        "max_completion_tokens": 8000
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text",
-          "image"
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -2830,30 +4073,44 @@
         "tokenizer": "Gemini"
       },
       "context_length": 1048576,
-      "created": 1737547899,
-      "description": "Gemini 2.0 Flash Thinking Experimental (01-21) is a snapshot of Gemini 2.0 Flash Thinking Experimental.\n\nGemini 2.0 Flash Thinking Mode is an experimental model that's trained to generate the \"thinking process\" the model goes through as part of its response. As a result, Thinking Mode is capable of stronger reasoning capabilities in its responses than the [base Gemini 2.0 Flash model](/google/gemini-2.0-flash-exp).",
-      "id": "google/gemini-2.0-flash-thinking-exp:free",
-      "name": "Google: Gemini 2.0 Flash Thinking Experimental 01-21 (free)",
+      "created": 1744914667,
+      "description": "Gemini 2.5 Flash is Google's state-of-the-art workhorse model, specifically designed for advanced reasoning, coding, mathematics, and scientific tasks. It includes built-in \"thinking\" capabilities, enabling it to provide responses with greater accuracy and nuanced context handling. \n\nNote: This model is available in two variants: thinking and non-thinking. The output pricing varies significantly depending on whether the thinking capability is active. If you select the standard variant (without the \":thinking\" suffix), the model will explicitly avoid generating thinking tokens. \n\nTo utilize the thinking capability and receive thinking tokens, you must choose the \":thinking\" variant, which will then incur the higher thinking-output pricing. \n\nAdditionally, Gemini 2.5 Flash is configurable through the \"max tokens for reasoning\" parameter, as described in the documentation (https://openrouter.ai/docs/use-cases/reasoning-tokens#max-tokens-for-reasoning).",
+      "hugging_face_id": "",
+      "id": "google/gemini-2.5-flash-preview",
+      "name": "Google: Gemini 2.5 Flash Preview 04-17",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0",
-        "image": "0",
+        "completion": "0.0000006",
+        "image": "0.0006192",
+        "input_cache_read": "0.0000000375",
+        "input_cache_write": "0.0000002333",
         "internal_reasoning": "0",
-        "prompt": "0",
+        "prompt": "0.00000015",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "tools",
+        "tool_choice",
+        "stop",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 1048576,
         "is_moderated": false,
-        "max_completion_tokens": 65536
+        "max_completion_tokens": 65535
       }
     },
     {
       "architecture": {
         "input_modalities": [
+          "image",
           "text",
-          "image"
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -2862,22 +4119,139 @@
         ],
         "tokenizer": "Gemini"
       },
-      "context_length": 1000000,
-      "created": 1742922099,
-      "description": "Gemini 2.5 Pro is Google’s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs “thinking” capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
-      "id": "google/gemini-2.5-pro-exp-03-25:free",
-      "name": "Google: Gemini 2.5 Pro Experimental (free)",
+      "context_length": 1048576,
+      "created": 1744914667,
+      "description": "Gemini 2.5 Flash is Google's state-of-the-art workhorse model, specifically designed for advanced reasoning, coding, mathematics, and scientific tasks. It includes built-in \"thinking\" capabilities, enabling it to provide responses with greater accuracy and nuanced context handling. \n\nNote: This model is available in two variants: thinking and non-thinking. The output pricing varies significantly depending on whether the thinking capability is active. If you select the standard variant (without the \":thinking\" suffix), the model will explicitly avoid generating thinking tokens. \n\nTo utilize the thinking capability and receive thinking tokens, you must choose the \":thinking\" variant, which will then incur the higher thinking-output pricing. \n\nAdditionally, Gemini 2.5 Flash is configurable through the \"max tokens for reasoning\" parameter, as described in the documentation (https://openrouter.ai/docs/use-cases/reasoning-tokens#max-tokens-for-reasoning).",
+      "hugging_face_id": "",
+      "id": "google/gemini-2.5-flash-preview:thinking",
+      "name": "Google: Gemini 2.5 Flash Preview 04-17 (thinking)",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0",
-        "image": "0",
+        "completion": "0.0000035",
+        "image": "0.0006192",
+        "input_cache_read": "0.0000000375",
+        "input_cache_write": "0.0000002333",
         "internal_reasoning": "0",
-        "prompt": "0",
+        "prompt": "0.00000015",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "tools",
+        "tool_choice",
+        "stop",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
-        "context_length": 1000000,
+        "context_length": 1048576,
+        "is_moderated": false,
+        "max_completion_tokens": 65535
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text",
+          "file"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini"
+      },
+      "context_length": 1048576,
+      "created": 1747761924,
+      "description": "Gemini 2.5 Flash May 20th Checkpoint is Google's state-of-the-art workhorse model, specifically designed for advanced reasoning, coding, mathematics, and scientific tasks. It includes built-in \"thinking\" capabilities, enabling it to provide responses with greater accuracy and nuanced context handling. \n\nNote: This model is available in two variants: thinking and non-thinking. The output pricing varies significantly depending on whether the thinking capability is active. If you select the standard variant (without the \":thinking\" suffix), the model will explicitly avoid generating thinking tokens. \n\nTo utilize the thinking capability and receive thinking tokens, you must choose the \":thinking\" variant, which will then incur the higher thinking-output pricing. \n\nAdditionally, Gemini 2.5 Flash is configurable through the \"max tokens for reasoning\" parameter, as described in the documentation (https://openrouter.ai/docs/use-cases/reasoning-tokens#max-tokens-for-reasoning).",
+      "hugging_face_id": "",
+      "id": "google/gemini-2.5-flash-preview-05-20",
+      "name": "Google: Gemini 2.5 Flash Preview 05-20",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000006",
+        "image": "0.0006192",
+        "input_cache_read": "0.0000000375",
+        "input_cache_write": "0.0000002333",
+        "internal_reasoning": "0",
+        "prompt": "0.00000015",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "structured_outputs",
+        "response_format",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed"
+      ],
+      "top_provider": {
+        "context_length": 1048576,
+        "is_moderated": false,
+        "max_completion_tokens": 65535
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text",
+          "file"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini"
+      },
+      "context_length": 1048576,
+      "created": 1747761924,
+      "description": "Gemini 2.5 Flash May 20th Checkpoint is Google's state-of-the-art workhorse model, specifically designed for advanced reasoning, coding, mathematics, and scientific tasks. It includes built-in \"thinking\" capabilities, enabling it to provide responses with greater accuracy and nuanced context handling. \n\nNote: This model is available in two variants: thinking and non-thinking. The output pricing varies significantly depending on whether the thinking capability is active. If you select the standard variant (without the \":thinking\" suffix), the model will explicitly avoid generating thinking tokens. \n\nTo utilize the thinking capability and receive thinking tokens, you must choose the \":thinking\" variant, which will then incur the higher thinking-output pricing. \n\nAdditionally, Gemini 2.5 Flash is configurable through the \"max tokens for reasoning\" parameter, as described in the documentation (https://openrouter.ai/docs/use-cases/reasoning-tokens#max-tokens-for-reasoning).",
+      "hugging_face_id": "",
+      "id": "google/gemini-2.5-flash-preview-05-20:thinking",
+      "name": "Google: Gemini 2.5 Flash Preview 05-20 (thinking)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000035",
+        "image": "0.0006192",
+        "input_cache_read": "0.0000000375",
+        "input_cache_write": "0.0000002333",
+        "internal_reasoning": "0",
+        "prompt": "0.00000015",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "structured_outputs",
+        "response_format",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed"
+      ],
+      "top_provider": {
+        "context_length": 1048576,
         "is_moderated": false,
         "max_completion_tokens": 65535
       }
@@ -2886,7 +4260,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -2895,91 +4270,84 @@
         ],
         "tokenizer": "Gemini"
       },
-      "context_length": 1000000,
-      "created": 1743780493,
+      "context_length": 1048576,
+      "created": 1742922099,
+      "description": "This model has been deprecated by Google in favor of the (paid Preview model)[google/gemini-2.5-pro-preview]\n \nGemini 2.5 Pro is Google’s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs “thinking” capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
+      "hugging_face_id": "",
+      "id": "google/gemini-2.5-pro-exp-03-25",
+      "name": "Google: Gemini 2.5 Pro Experimental",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "tools",
+        "tool_choice",
+        "stop",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
+      "top_provider": {
+        "context_length": 1048576,
+        "is_moderated": false,
+        "max_completion_tokens": 65535
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text",
+          "image",
+          "file"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini"
+      },
+      "context_length": 1048576,
+      "created": 1746578513,
       "description": "Gemini 2.5 Pro is Google’s state-of-the-art AI model designed for advanced reasoning, coding, mathematics, and scientific tasks. It employs “thinking” capabilities, enabling it to reason through responses with enhanced accuracy and nuanced context handling. Gemini 2.5 Pro achieves top-tier performance on multiple benchmarks, including first-place positioning on the LMArena leaderboard, reflecting superior human-preference alignment and complex problem-solving abilities.",
-      "id": "google/gemini-2.5-pro-preview-03-25",
+      "hugging_face_id": "",
+      "id": "google/gemini-2.5-pro-preview",
       "name": "Google: Gemini 2.5 Pro Preview",
       "per_request_limits": null,
       "pricing": {
         "completion": "0.00001",
         "image": "0.00516",
-        "input_cache_read": "0.0000003125",
-        "input_cache_write": "0",
+        "input_cache_read": "0.00000031",
+        "input_cache_write": "0.000001625",
         "internal_reasoning": "0",
         "prompt": "0.00000125",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "tools",
+        "tool_choice",
+        "stop",
+        "seed",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
-        "context_length": 1000000,
+        "context_length": 1048576,
         "is_moderated": false,
         "max_completion_tokens": 65535
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Gemini"
-      },
-      "context_length": 32760,
-      "created": 1702425600,
-      "description": "Google's flagship text generation model. Designed to handle natural language tasks, multiturn text and code chat, and code generation.\n\nSee the benchmarks and prompting guidelines from [Deepmind](https://deepmind.google/technologies/gemini/).\n\nUsage of Gemini is subject to Google's [Gemini Terms of Use](https://ai.google.dev/terms).",
-      "id": "google/gemini-pro",
-      "name": "Google: Gemini Pro 1.0",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000015",
-        "image": "0.0025",
-        "internal_reasoning": "0",
-        "prompt": "0.0000005",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 32760,
-        "is_moderated": false,
-        "max_completion_tokens": 8192
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "instruct_type": null,
-        "modality": "text+image->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Gemini"
-      },
-      "context_length": 16384,
-      "created": 1702425600,
-      "description": "Google's flagship multimodal model, supporting image and video in text or chat prompts for a text or code response.\n\nSee the benchmarks and prompting guidelines from [Deepmind](https://deepmind.google/technologies/gemini/).\n\nUsage of Gemini is subject to Google's [Gemini Terms of Use](https://ai.google.dev/terms).\n\n#multimodal",
-      "id": "google/gemini-pro-vision",
-      "name": "Google: Gemini Pro Vision 1.0",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000015",
-        "image": "0.0025",
-        "internal_reasoning": "0",
-        "prompt": "0.0000005",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 16384,
-        "is_moderated": false,
-        "max_completion_tokens": 2048
       }
     },
     {
@@ -2997,49 +4365,34 @@
       "context_length": 8192,
       "created": 1720828800,
       "description": "Gemma 2 27B by Google is an open model built from the same research and technology used to create the [Gemini models](/models?q=gemini).\n\nGemma models are well-suited for a variety of text generation tasks, including question answering, summarization, and reasoning.\n\nSee the [launch announcement](https://blog.google/technology/developers/google-gemma-2/) for more details. Usage of Gemma is subject to Google's [Gemma Terms of Use](https://ai.google.dev/gemma/terms).",
+      "hugging_face_id": "google/gemma-2-27b-it",
       "id": "google/gemma-2-27b-it",
       "name": "Google: Gemma 2 27B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000008",
+        "completion": "0.0000003",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000008",
+        "prompt": "0.0000001",
         "request": "0",
         "web_search": "0"
       },
-      "top_provider": {
-        "context_length": 8192,
-        "is_moderated": false,
-        "max_completion_tokens": 2048
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "gemma",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Gemini"
-      },
-      "context_length": 8192,
-      "created": 1719532800,
-      "description": "Gemma 2 9B by Google is an advanced, open-source language model that sets a new standard for efficiency and performance in its size class.\n\nDesigned for a wide variety of tasks, it empowers developers and researchers to build innovative applications, while maintaining accessibility, safety, and cost-effectiveness.\n\nSee the [launch announcement](https://blog.google/technology/developers/google-gemma-2/) for more details. Usage of Gemma is subject to Google's [Gemma Terms of Use](https://ai.google.dev/gemma/terms).",
-      "id": "google/gemma-2-9b-it",
-      "name": "Google: Gemma 2 9B",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.00000007",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.00000007",
-        "request": "0",
-        "web_search": "0"
-      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -3061,6 +4414,56 @@
       "context_length": 8192,
       "created": 1719532800,
       "description": "Gemma 2 9B by Google is an advanced, open-source language model that sets a new standard for efficiency and performance in its size class.\n\nDesigned for a wide variety of tasks, it empowers developers and researchers to build innovative applications, while maintaining accessibility, safety, and cost-effectiveness.\n\nSee the [launch announcement](https://blog.google/technology/developers/google-gemma-2/) for more details. Usage of Gemma is subject to Google's [Gemma Terms of Use](https://ai.google.dev/gemma/terms).",
+      "hugging_face_id": "google/gemma-2-9b-it",
+      "id": "google/gemma-2-9b-it",
+      "name": "Google: Gemma 2 9B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000006",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000002",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "response_format",
+        "top_logprobs",
+        "logprobs"
+      ],
+      "top_provider": {
+        "context_length": 8192,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "gemma",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini"
+      },
+      "context_length": 8192,
+      "created": 1719532800,
+      "description": "Gemma 2 9B by Google is an advanced, open-source language model that sets a new standard for efficiency and performance in its size class.\n\nDesigned for a wide variety of tasks, it empowers developers and researchers to build innovative applications, while maintaining accessibility, safety, and cost-effectiveness.\n\nSee the [launch announcement](https://blog.google/technology/developers/google-gemma-2/) for more details. Usage of Gemma is subject to Google's [Gemma Terms of Use](https://ai.google.dev/gemma/terms).",
+      "hugging_face_id": "google/gemma-2-9b-it",
       "id": "google/gemma-2-9b-it:free",
       "name": "Google: Gemma 2 9B (free)",
       "per_request_limits": null,
@@ -3072,6 +4475,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -3094,6 +4512,7 @@
       "context_length": 131072,
       "created": 1741902625,
       "description": "Gemma 3 introduces multimodality, supporting vision-language input and text outputs. It handles context windows up to 128k tokens, understands over 140 languages, and offers improved math, reasoning, and chat capabilities, including structured outputs and function calling. Gemma 3 12B is the second largest in the family of Gemma 3 models after [Gemma 3 27B](google/gemma-3-27b-it)",
+      "hugging_face_id": "google/gemma-3-12b-it",
       "id": "google/gemma-3-12b-it",
       "name": "Google: Gemma 3 12B",
       "per_request_limits": null,
@@ -3105,6 +4524,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -3124,9 +4556,10 @@
         ],
         "tokenizer": "Gemini"
       },
-      "context_length": 131072,
+      "context_length": 96000,
       "created": 1741902625,
       "description": "Gemma 3 introduces multimodality, supporting vision-language input and text outputs. It handles context windows up to 128k tokens, understands over 140 languages, and offers improved math, reasoning, and chat capabilities, including structured outputs and function calling. Gemma 3 12B is the second largest in the family of Gemma 3 models after [Gemma 3 27B](google/gemma-3-27b-it)",
+      "hugging_face_id": "google/gemma-3-12b-it",
       "id": "google/gemma-3-12b-it:free",
       "name": "Google: Gemma 3 12B (free)",
       "per_request_limits": null,
@@ -3138,8 +4571,25 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
-        "context_length": 131072,
+        "context_length": 96000,
         "is_moderated": false,
         "max_completion_tokens": 8192
       }
@@ -3160,6 +4610,7 @@
       "context_length": 32768,
       "created": 1741963556,
       "description": "Gemma 3 1B is the smallest of the new Gemma 3 family. It handles context windows up to 32k tokens, understands over 140 languages, and offers improved math, reasoning, and chat capabilities, including structured outputs and function calling. Note: Gemma 3 1B is not multimodal. For the smallest multimodal Gemma 3 model, please see [Gemma 3 4B](google/gemma-3-4b-it)",
+      "hugging_face_id": "google/gemma-3-1b-it",
       "id": "google/gemma-3-1b-it:free",
       "name": "Google: Gemma 3 1B (free)",
       "per_request_limits": null,
@@ -3171,6 +4622,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -3193,6 +4659,7 @@
       "context_length": 131072,
       "created": 1741756359,
       "description": "Gemma 3 introduces multimodality, supporting vision-language input and text outputs. It handles context windows up to 128k tokens, understands over 140 languages, and offers improved math, reasoning, and chat capabilities, including structured outputs and function calling. Gemma 3 27B is Google's latest open source model, successor to [Gemma 2](google/gemma-2-27b-it)",
+      "hugging_face_id": "",
       "id": "google/gemma-3-27b-it",
       "name": "Google: Gemma 3 27B",
       "per_request_limits": null,
@@ -3204,10 +4671,26 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p",
+        "logit_bias",
+        "top_logprobs",
+        "logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -3226,6 +4709,7 @@
       "context_length": 96000,
       "created": 1741756359,
       "description": "Gemma 3 introduces multimodality, supporting vision-language input and text outputs. It handles context windows up to 128k tokens, understands over 140 languages, and offers improved math, reasoning, and chat capabilities, including structured outputs and function calling. Gemma 3 27B is Google's latest open source model, successor to [Gemma 2](google/gemma-2-27b-it)",
+      "hugging_face_id": "",
       "id": "google/gemma-3-27b-it:free",
       "name": "Google: Gemma 3 27B (free)",
       "per_request_limits": null,
@@ -3237,6 +4721,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 96000,
         "is_moderated": false,
@@ -3259,6 +4760,7 @@
       "context_length": 131072,
       "created": 1741905510,
       "description": "Gemma 3 introduces multimodality, supporting vision-language input and text outputs. It handles context windows up to 128k tokens, understands over 140 languages, and offers improved math, reasoning, and chat capabilities, including structured outputs and function calling.",
+      "hugging_face_id": "google/gemma-3-4b-it",
       "id": "google/gemma-3-4b-it",
       "name": "Google: Gemma 3 4B",
       "per_request_limits": null,
@@ -3270,6 +4772,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -3289,9 +4804,10 @@
         ],
         "tokenizer": "Gemini"
       },
-      "context_length": 131072,
+      "context_length": 96000,
       "created": 1741905510,
       "description": "Gemma 3 introduces multimodality, supporting vision-language input and text outputs. It handles context windows up to 128k tokens, understands over 140 languages, and offers improved math, reasoning, and chat capabilities, including structured outputs and function calling.",
+      "hugging_face_id": "google/gemma-3-4b-it",
       "id": "google/gemma-3-4b-it:free",
       "name": "Google: Gemma 3 4B (free)",
       "per_request_limits": null,
@@ -3303,8 +4819,25 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
-        "context_length": 131072,
+        "context_length": 96000,
         "is_moderated": false,
         "max_completion_tokens": 8192
       }
@@ -3312,21 +4845,21 @@
     {
       "architecture": {
         "input_modalities": [
-          "text",
-          "image"
+          "text"
         ],
         "instruct_type": null,
-        "modality": "text+image->text",
+        "modality": "text->text",
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Gemini"
+        "tokenizer": "Other"
       },
-      "context_length": 40960,
-      "created": 1732216551,
-      "description": "An experimental version of [Gemini 1.5 Pro](/google/gemini-pro-1.5) from Google.",
-      "id": "google/learnlm-1.5-pro-experimental:free",
-      "name": "Google: LearnLM 1.5 Pro Experimental (free)",
+      "context_length": 8192,
+      "created": 1747776824,
+      "description": "Gemma 3n E4B-it is optimized for efficient execution on mobile and low-resource devices, such as phones, laptops, and tablets. It supports multimodal inputs—including text, visual data, and audio—enabling diverse tasks such as text generation, speech recognition, translation, and image analysis. Leveraging innovations like Per-Layer Embedding (PLE) caching and the MatFormer architecture, Gemma 3n dynamically manages memory usage and computational load by selectively activating model parameters, significantly reducing runtime resource requirements.\n\nThis model supports a wide linguistic range (trained in over 140 languages) and features a flexible 32K token context window. Gemma 3n can selectively load parameters, optimizing memory and computational efficiency based on the task or device capabilities, making it well-suited for privacy-focused, offline-capable applications and on-device AI solutions. [Read more in the blog post](https://developers.googleblog.com/en/introducing-gemma-3n/)",
+      "hugging_face_id": "",
+      "id": "google/gemma-3n-e4b-it:free",
+      "name": "Google: Gemma 3n 4B (free)",
       "per_request_limits": null,
       "pricing": {
         "completion": "0",
@@ -3336,170 +4869,59 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "response_format"
+      ],
       "top_provider": {
-        "context_length": 40960,
-        "is_moderated": false,
-        "max_completion_tokens": 8192
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "PaLM"
-      },
-      "context_length": 9216,
-      "created": 1689811200,
-      "description": "PaLM 2 is a language model by Google with improved multilingual, reasoning and coding capabilities.",
-      "id": "google/palm-2-chat-bison",
-      "name": "Google: PaLM 2 Chat",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000002",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.000001",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 9216,
-        "is_moderated": false,
-        "max_completion_tokens": 1024
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "PaLM"
-      },
-      "context_length": 32768,
-      "created": 1698969600,
-      "description": "PaLM 2 is a language model by Google with improved multilingual, reasoning and coding capabilities.",
-      "id": "google/palm-2-chat-bison-32k",
-      "name": "Google: PaLM 2 Chat 32k",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000002",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.000001",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "is_moderated": false,
-        "max_completion_tokens": 8192
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "PaLM"
-      },
-      "context_length": 7168,
-      "created": 1689811200,
-      "description": "PaLM 2 fine-tuned for chatbot conversations that help with code-related questions.",
-      "id": "google/palm-2-codechat-bison",
-      "name": "Google: PaLM 2 Code Chat",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000002",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.000001",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 7168,
-        "is_moderated": false,
-        "max_completion_tokens": 1024
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "PaLM"
-      },
-      "context_length": 32768,
-      "created": 1698969600,
-      "description": "PaLM 2 fine-tuned for chatbot conversations that help with code-related questions.",
-      "id": "google/palm-2-codechat-bison-32k",
-      "name": "Google: PaLM 2 Code Chat 32k",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000002",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.000001",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "is_moderated": false,
-        "max_completion_tokens": 8192
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "zephyr",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral"
-      },
-      "context_length": 4096,
-      "created": 1690934400,
-      "description": "Zephyr is a series of language models that are trained to act as helpful assistants. Zephyr-7B-β is the second model in the series, and is a fine-tuned version of [mistralai/Mistral-7B-v0.1](/models/mistralai/mistral-7b-instruct-v0.1) that was trained on a mix of publicly available, synthetic datasets using Direct Preference Optimization (DPO).",
-      "id": "huggingfaceh4/zephyr-7b-beta:free",
-      "name": "Hugging Face: Zephyr 7B (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 4096,
+        "context_length": 8192,
         "is_moderated": false,
         "max_completion_tokens": 2048
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32000,
+      "created": 1746033880,
+      "description": "Mercury Coder Small is the first diffusion large language model (dLLM). Applying a breakthrough discrete diffusion approach, the model runs 5-10x faster than even speed optimized models like Claude 3.5 Haiku and GPT-4o Mini while matching their performance. Mercury Coder Small's speed means that developers can stay in the flow while coding, enjoying rapid chat-based iteration and responsive code completion suggestions. On Copilot Arena, Mercury Coder ranks 1st in speed and ties for 2nd in quality. Read more in the [blog post here](https://www.inceptionlabs.ai/introducing-mercury).",
+      "hugging_face_id": "",
+      "id": "inception/mercury-coder-small-beta",
+      "name": "Inception: Mercury Coder Small Beta",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.000001",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000025",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop"
+      ],
+      "top_provider": {
+        "context_length": 32000,
+        "is_moderated": false,
+        "max_completion_tokens": null
       }
     },
     {
@@ -3517,6 +4939,7 @@
       "context_length": 16384,
       "created": 1731464428,
       "description": "Inferor 12B is a merge of top roleplay models, expert on immersive narratives and storytelling.\n\nThis model was merged using the [Model Stock](https://arxiv.org/abs/2403.19522) merge method using [anthracite-org/magnum-v4-12b](https://openrouter.ai/anthracite-org/magnum-v4-72b) as a base.\n",
+      "hugging_face_id": "Infermatic/MN-12B-Inferor-v0.0",
       "id": "infermatic/mn-inferor-12b",
       "name": "Infermatic: Mistral Nemo Inferor 12B",
       "per_request_limits": null,
@@ -3528,6 +4951,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -3549,6 +4984,7 @@
       "context_length": 8000,
       "created": 1728604800,
       "description": "Inflection 3 Pi powers Inflection's [Pi](https://pi.ai) chatbot, including backstory, emotional intelligence, productivity, and safety. It has access to recent news, and excels in scenarios like customer support and roleplay.\n\nPi has been trained to mirror your tone and style, if you use more emojis, so will Pi! Try experimenting with various prompts and conversation styles.",
+      "hugging_face_id": null,
       "id": "inflection/inflection-3-pi",
       "name": "Inflection: Inflection 3 Pi",
       "per_request_limits": null,
@@ -3560,6 +4996,12 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 8000,
         "is_moderated": false,
@@ -3581,6 +5023,7 @@
       "context_length": 8000,
       "created": 1728604800,
       "description": "Inflection 3 Productivity is optimized for following instructions. It is better for tasks requiring JSON output or precise adherence to provided guidelines. It has access to recent news.\n\nFor emotional intelligence similar to Pi, see [Inflect 3 Pi](/inflection/inflection-3-pi)\n\nSee [Inflection's announcement](https://inflection.ai/blog/enterprise) for more details.",
+      "hugging_face_id": null,
       "id": "inflection/inflection-3-productivity",
       "name": "Inflection: Inflection 3 Productivity",
       "per_request_limits": null,
@@ -3592,42 +5035,16 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop"
+      ],
       "top_provider": {
         "context_length": 8000,
         "is_moderated": false,
         "max_completion_tokens": 1024
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3"
-      },
-      "context_length": 131072,
-      "created": 1741636885,
-      "description": "Wayfarer Large 70B is a roleplay and text-adventure model fine-tuned from Meta’s Llama-3.3-70B-Instruct. Specifically optimized for narrative-driven, challenging scenarios, it introduces realistic stakes, conflicts, and consequences often avoided by standard RLHF-aligned models. Trained using a curated blend of adventure, roleplay, and instructive fiction datasets, Wayfarer emphasizes tense storytelling, authentic player failure scenarios, and robust narrative immersion, making it uniquely suited for interactive fiction and gaming experiences.",
-      "id": "latitudegames/wayfarer-large-70b-llama-3.3",
-      "name": "LatitudeGames: Wayfarer Large 70B Llama 3.3",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000009",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.0000008",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "is_moderated": false,
-        "max_completion_tokens": 131072
       }
     },
     {
@@ -3645,6 +5062,7 @@
       "context_length": 32768,
       "created": 1737806501,
       "description": "Liquid's LFM 3B delivers incredible performance for its size. It positions itself as first place among 3B parameter transformers, hybrids, and RNN models It is also on par with Phi-3.5-mini on multiple benchmarks, while being 18.4% smaller.\n\nLFM-3B is the ideal choice for mobile and other edge text-based applications.\n\nSee the [launch announcement](https://www.liquid.ai/liquid-foundation-models) for benchmarks and more info.",
+      "hugging_face_id": "",
       "id": "liquid/lfm-3b",
       "name": "Liquid: LFM 3B",
       "per_request_limits": null,
@@ -3656,6 +5074,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -3677,6 +5107,7 @@
       "context_length": 32768,
       "created": 1727654400,
       "description": "Liquid's 40.3B Mixture of Experts (MoE) model. Liquid Foundation Models (LFMs) are large neural networks built with computational units rooted in dynamic systems.\n\nLFMs are general-purpose AI models that can be used to model any kind of sequential data, including video, audio, text, time series, and signals.\n\nSee the [launch announcement](https://www.liquid.ai/liquid-foundation-models) for benchmarks and more info.",
+      "hugging_face_id": null,
       "id": "liquid/lfm-40b",
       "name": "Liquid: LFM 40B MoE",
       "per_request_limits": null,
@@ -3688,6 +5119,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -3709,6 +5156,7 @@
       "context_length": 32768,
       "created": 1737806883,
       "description": "LFM-7B, a new best-in-class language model. LFM-7B is designed for exceptional chat capabilities, including languages like Arabic and Japanese. Powered by the Liquid Foundation Model (LFM) architecture, it exhibits unique features like low memory footprint and fast inference speed. \n\nLFM-7B is the world’s best-in-class multilingual language model in English, Arabic, and Japanese.\n\nSee the [launch announcement](https://www.liquid.ai/lfm-7b) for benchmarks and more info.",
+      "hugging_face_id": "",
       "id": "liquid/lfm-7b",
       "name": "Liquid: LFM 7B",
       "per_request_limits": null,
@@ -3720,6 +5168,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -3738,22 +5202,39 @@
         ],
         "tokenizer": "Llama3"
       },
-      "context_length": 8192,
+      "context_length": 131072,
       "created": 1739401318,
       "description": "Llama Guard 3 is a Llama-3.1-8B pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM – it generates text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated.\n\nLlama Guard 3 was aligned to safeguard against the MLCommons standardized hazards taxonomy and designed to support Llama 3.1 capabilities. Specifically, it provides content moderation in 8 languages, and was optimized to support safety and security for search and code interpreter tool calls.\n",
+      "hugging_face_id": "meta-llama/Llama-Guard-3-8B",
       "id": "meta-llama/llama-guard-3-8b",
       "name": "Llama Guard 3 8B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000002",
+        "completion": "0.00000006",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000002",
+        "prompt": "0.00000002",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "top_logprobs",
+        "logprobs",
+        "seed"
+      ],
       "top_provider": {
-        "context_length": 8192,
+        "context_length": 131072,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -3773,21 +5254,34 @@
       "context_length": 16384,
       "created": 1720656000,
       "description": "From the maker of [Goliath](https://openrouter.ai/models/alpindale/goliath-120b), Magnum 72B is the first in a new family of models designed to achieve the prose quality of the Claude 3 models, notably Opus & Sonnet.\n\nThe model is based on [Qwen2 72B](https://openrouter.ai/models/qwen/qwen-2-72b-instruct) and trained with 55 million tokens of highly curated roleplay (RP) data.",
+      "hugging_face_id": "alpindale/magnum-72b-v1",
       "id": "alpindale/magnum-72b",
       "name": "Magnum 72B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000225",
+        "completion": "0.000006",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000015",
+        "prompt": "0.000004",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
-        "max_completion_tokens": 1024
+        "max_completion_tokens": 4096
       }
     },
     {
@@ -3805,6 +5299,7 @@
       "context_length": 32768,
       "created": 1727654400,
       "description": "From the maker of [Goliath](https://openrouter.ai/models/alpindale/goliath-120b), Magnum 72B is the seventh in a family of models designed to achieve the prose quality of the Claude 3 models, notably Opus & Sonnet.\n\nThe model is based on [Qwen2 72B](https://openrouter.ai/models/qwen/qwen-2-72b-instruct) and trained with 55 million tokens of highly curated roleplay (RP) data.",
+      "hugging_face_id": "anthracite-org/magnum-v2-72b",
       "id": "anthracite-org/magnum-v2-72b",
       "name": "Magnum v2 72B",
       "per_request_limits": null,
@@ -3816,6 +5311,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -3837,17 +5345,32 @@
       "context_length": 16384,
       "created": 1729555200,
       "description": "This is a series of models designed to replicate the prose quality of the Claude 3 models, specifically Sonnet(https://openrouter.ai/anthropic/claude-3.5-sonnet) and Opus(https://openrouter.ai/anthropic/claude-3-opus).\n\nThe model is fine-tuned on top of [Qwen2.5 72B](https://openrouter.ai/qwen/qwen-2.5-72b-instruct).",
+      "hugging_face_id": "anthracite-org/magnum-v4-72b",
       "id": "anthracite-org/magnum-v4-72b",
       "name": "Magnum v4 72B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000225",
+        "completion": "0.000003",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000015",
+        "prompt": "0.0000025",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed",
+        "logit_bias",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -3869,17 +5392,32 @@
       "context_length": 8000,
       "created": 1690934400,
       "description": "An attempt to recreate Claude-style verbosity, but don't expect the same level of coherence or memory. Meant for use in roleplay/narrative situations.",
+      "hugging_face_id": null,
       "id": "mancer/weaver",
       "name": "Mancer: Weaver (alpha)",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000001125",
+        "completion": "0.0000015",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.000001125",
+        "prompt": "0.0000015",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 8000,
         "is_moderated": false,
@@ -3900,39 +5438,8 @@
       },
       "context_length": 4096,
       "created": 1687219200,
-      "description": "A 13 billion parameter language model from Meta, fine tuned for chat completions",
-      "id": "meta-llama/llama-2-13b-chat",
-      "name": "Meta: Llama 2 13B Chat",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.00000022",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.00000022",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 4096,
-        "is_moderated": false,
-        "max_completion_tokens": 2048
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "llama2",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama2"
-      },
-      "context_length": 4096,
-      "created": 1687219200,
       "description": "The flagship, 70 billion parameter language model from Meta, fine tuned for chat completions. Llama 2 is an auto-regressive language model that uses an optimized transformer architecture. The tuned versions use supervised fine-tuning (SFT) and reinforcement learning with human feedback (RLHF) to align to human preferences for helpfulness and safety.",
+      "hugging_face_id": "meta-llama/Llama-2-70b-chat-hf",
       "id": "meta-llama/llama-2-70b-chat",
       "name": "Meta: Llama 2 70B Chat",
       "per_request_limits": null,
@@ -3944,6 +5451,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
@@ -3965,6 +5485,7 @@
       "context_length": 8192,
       "created": 1713398400,
       "description": "Meta's latest class of model (Llama 3) launched with a variety of sizes & flavors. This 70B instruct-tuned version was optimized for high quality dialogue usecases.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Meta-Llama-3-70B-Instruct",
       "id": "meta-llama/llama-3-70b-instruct",
       "name": "Meta: Llama 3 70B Instruct",
       "per_request_limits": null,
@@ -3976,10 +5497,28 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "top_logprobs",
+        "logprobs",
+        "seed",
+        "tools",
+        "tool_choice"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -3997,6 +5536,7 @@
       "context_length": 8192,
       "created": 1713398400,
       "description": "Meta's latest class of model (Llama 3) launched with a variety of sizes & flavors. This 8B instruct-tuned version was optimized for high quality dialogue usecases.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Meta-Llama-3-8B-Instruct",
       "id": "meta-llama/llama-3-8b-instruct",
       "name": "Meta: Llama 3 8B Instruct",
       "per_request_limits": null,
@@ -4008,10 +5548,29 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "seed",
+        "repetition_penalty",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop",
+        "min_p",
+        "logit_bias",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "top_logprobs",
+        "logprobs",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4029,6 +5588,7 @@
       "context_length": 32768,
       "created": 1722556800,
       "description": "Meta's latest class of model (Llama 3.1) launched with a variety of sizes & flavors. This is the base 405B pre-trained version.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/llama-3.1-405B",
       "id": "meta-llama/llama-3.1-405b",
       "name": "Meta: Llama 3.1 405B (base)",
       "per_request_limits": null,
@@ -4040,8 +5600,71 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "repetition_penalty"
+      ],
       "top_provider": {
         "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "none",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Llama3"
+      },
+      "context_length": 64000,
+      "created": 1722556800,
+      "description": "Meta's latest class of model (Llama 3.1) launched with a variety of sizes & flavors. This is the base 405B pre-trained version.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/llama-3.1-405B",
+      "id": "meta-llama/llama-3.1-405b:free",
+      "name": "Meta: Llama 3.1 405B (base) (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 64000,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -4061,6 +5684,7 @@
       "context_length": 32768,
       "created": 1721692800,
       "description": "The highly anticipated 400B class of Llama3 is here! Clocking in at 128k context with impressive eval scores, the Meta AI team continues to push the frontier of open-source LLMs.\n\nMeta's latest class of model (Llama 3.1) launched with a variety of sizes & flavors. This 405B instruct-tuned version is optimized for high quality dialogue usecases.\n\nIt has demonstrated strong performance compared to leading closed-source models including GPT-4o and Claude 3.5 Sonnet in evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3-1/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Meta-Llama-3.1-405B-Instruct",
       "id": "meta-llama/llama-3.1-405b-instruct",
       "name": "Meta: Llama 3.1 405B Instruct",
       "per_request_limits": null,
@@ -4072,10 +5696,29 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "response_format",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4093,6 +5736,7 @@
       "context_length": 131072,
       "created": 1721692800,
       "description": "Meta's latest class of model (Llama 3.1) launched with a variety of sizes & flavors. This 70B instruct-tuned version is optimized for high quality dialogue usecases.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3-1/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Meta-Llama-3.1-70B-Instruct",
       "id": "meta-llama/llama-3.1-70b-instruct",
       "name": "Meta: Llama 3.1 70B Instruct",
       "per_request_limits": null,
@@ -4100,14 +5744,33 @@
         "completion": "0.00000028",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000012",
+        "prompt": "0.0000001",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4122,24 +5785,44 @@
         ],
         "tokenizer": "Llama3"
       },
-      "context_length": 131072,
+      "context_length": 16384,
       "created": 1721692800,
       "description": "Meta's latest class of model (Llama 3.1) launched with a variety of sizes & flavors. This 8B instruct-tuned version is fast and efficient.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3-1/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
       "id": "meta-llama/llama-3.1-8b-instruct",
       "name": "Meta: Llama 3.1 8B Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000000045",
+        "completion": "0.00000003",
         "image": "0",
         "internal_reasoning": "0",
         "prompt": "0.00000002",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "top_k",
+        "repetition_penalty",
+        "structured_outputs",
+        "min_p"
+      ],
       "top_provider": {
-        "context_length": 131072,
+        "context_length": 16384,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4157,6 +5840,7 @@
       "context_length": 131072,
       "created": 1721692800,
       "description": "Meta's latest class of model (Llama 3.1) launched with a variety of sizes & flavors. This 8B instruct-tuned version is fast and efficient.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3-1/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
       "id": "meta-llama/llama-3.1-8b-instruct:free",
       "name": "Meta: Llama 3.1 8B Instruct (free)",
       "per_request_limits": null,
@@ -4168,6 +5852,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -4190,6 +5883,7 @@
       "context_length": 131072,
       "created": 1727222400,
       "description": "Llama 3.2 11B Vision is a multimodal model with 11 billion parameters, designed to handle tasks combining visual and textual data. It excels in tasks such as image captioning and visual question answering, bridging the gap between language generation and visual reasoning. Pre-trained on a massive dataset of image-text pairs, it performs well in complex, high-accuracy image analysis.\n\nIts ability to integrate visual understanding with language processing makes it an ideal solution for industries requiring comprehensive visual-linguistic AI applications, such as content creation, AI-driven customer service, and research.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD_VISION.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
       "id": "meta-llama/llama-3.2-11b-vision-instruct",
       "name": "Meta: Llama 3.2 11B Vision Instruct",
       "per_request_limits": null,
@@ -4201,10 +5895,28 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "response_format",
+        "top_logprobs",
+        "tools",
+        "tool_choice",
+        "logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4223,6 +5935,7 @@
       "context_length": 131072,
       "created": 1727222400,
       "description": "Llama 3.2 11B Vision is a multimodal model with 11 billion parameters, designed to handle tasks combining visual and textual data. It excels in tasks such as image captioning and visual question answering, bridging the gap between language generation and visual reasoning. Pre-trained on a massive dataset of image-text pairs, it performs well in complex, high-accuracy image analysis.\n\nIts ability to integrate visual understanding with language processing makes it an ideal solution for industries requiring comprehensive visual-linguistic AI applications, such as content creation, AI-driven customer service, and research.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD_VISION.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
       "id": "meta-llama/llama-3.2-11b-vision-instruct:free",
       "name": "Meta: Llama 3.2 11B Vision Instruct (free)",
       "per_request_limits": null,
@@ -4234,6 +5947,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -4255,6 +5981,7 @@
       "context_length": 131072,
       "created": 1727222400,
       "description": "Llama 3.2 1B is a 1-billion-parameter language model focused on efficiently performing natural language tasks, such as summarization, dialogue, and multilingual text analysis. Its smaller size allows it to operate efficiently in low-resource environments while maintaining strong task performance.\n\nSupporting eight core languages and fine-tunable for more, Llama 1.3B is ideal for businesses or developers seeking lightweight yet powerful AI solutions that can operate in diverse multilingual settings without the high computational demand of larger models.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Llama-3.2-1B-Instruct",
       "id": "meta-llama/llama-3.2-1b-instruct",
       "name": "Meta: Llama 3.2 1B Instruct",
       "per_request_limits": null,
@@ -4262,12 +5989,74 @@
         "completion": "0.00000001",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000001",
+        "prompt": "0.000000005",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "min_p",
+        "logit_bias",
+        "top_logprobs",
+        "logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": 16384
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "llama3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Llama3"
+      },
+      "context_length": 131000,
+      "created": 1727222400,
+      "description": "Llama 3.2 1B is a 1-billion-parameter language model focused on efficiently performing natural language tasks, such as summarization, dialogue, and multilingual text analysis. Its smaller size allows it to operate efficiently in low-resource environments while maintaining strong task performance.\n\nSupporting eight core languages and fine-tunable for more, Llama 1.3B is ideal for businesses or developers seeking lightweight yet powerful AI solutions that can operate in diverse multilingual settings without the high computational demand of larger models.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Llama-3.2-1B-Instruct",
+      "id": "meta-llama/llama-3.2-1b-instruct:free",
+      "name": "Meta: Llama 3.2 1B Instruct (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 131000,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -4286,54 +6075,41 @@
       },
       "context_length": 131072,
       "created": 1727222400,
-      "description": "Llama 3.2 1B is a 1-billion-parameter language model focused on efficiently performing natural language tasks, such as summarization, dialogue, and multilingual text analysis. Its smaller size allows it to operate efficiently in low-resource environments while maintaining strong task performance.\n\nSupporting eight core languages and fine-tunable for more, Llama 1.3B is ideal for businesses or developers seeking lightweight yet powerful AI solutions that can operate in diverse multilingual settings without the high computational demand of larger models.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
-      "id": "meta-llama/llama-3.2-1b-instruct:free",
-      "name": "Meta: Llama 3.2 1B Instruct (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "is_moderated": false,
-        "max_completion_tokens": 131072
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "llama3",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3"
-      },
-      "context_length": 131072,
-      "created": 1727222400,
       "description": "Llama 3.2 3B is a 3-billion-parameter multilingual large language model, optimized for advanced natural language processing tasks like dialogue generation, reasoning, and summarization. Designed with the latest transformer architecture, it supports eight languages, including English, Spanish, and Hindi, and is adaptable for additional languages.\n\nTrained on 9 trillion tokens, the Llama 3.2 3B model excels in instruction-following, complex reasoning, and tool use. Its balanced performance makes it ideal for applications needing accuracy and efficiency in text generation across multilingual settings.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Llama-3.2-3B-Instruct",
       "id": "meta-llama/llama-3.2-3b-instruct",
       "name": "Meta: Llama 3.2 3B Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000000025",
+        "completion": "0.00000002",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.000000015",
+        "prompt": "0.00000001",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "top_k",
+        "min_p",
+        "repetition_penalty"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 131072
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4351,6 +6127,7 @@
       "context_length": 20000,
       "created": 1727222400,
       "description": "Llama 3.2 3B is a 3-billion-parameter multilingual large language model, optimized for advanced natural language processing tasks like dialogue generation, reasoning, and summarization. Designed with the latest transformer architecture, it supports eight languages, including English, Spanish, and Hindi, and is adaptable for additional languages.\n\nTrained on 9 trillion tokens, the Llama 3.2 3B model excels in instruction-following, complex reasoning, and tool use. Its balanced performance makes it ideal for applications needing accuracy and efficiency in text generation across multilingual settings.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Llama-3.2-3B-Instruct",
       "id": "meta-llama/llama-3.2-3b-instruct:free",
       "name": "Meta: Llama 3.2 3B Instruct (free)",
       "per_request_limits": null,
@@ -4362,6 +6139,11 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p"
+      ],
       "top_provider": {
         "context_length": 20000,
         "is_moderated": false,
@@ -4381,24 +6163,39 @@
         ],
         "tokenizer": "Llama3"
       },
-      "context_length": 4096,
+      "context_length": 131072,
       "created": 1727222400,
       "description": "The Llama 90B Vision model is a top-tier, 90-billion-parameter multimodal model designed for the most challenging visual reasoning and language tasks. It offers unparalleled accuracy in image captioning, visual question answering, and advanced image-text comprehension. Pre-trained on vast multimodal datasets and fine-tuned with human feedback, the Llama 90B Vision is engineered to handle the most demanding image-based AI tasks.\n\nThis model is perfect for industries requiring cutting-edge multimodal AI capabilities, particularly those dealing with complex, real-time visual and textual analysis.\n\nClick here for the [original model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/MODEL_CARD_VISION.md).\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Llama-3.2-90B-Vision-Instruct",
       "id": "meta-llama/llama-3.2-90b-vision-instruct",
       "name": "Meta: Llama 3.2 90B Vision Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000016",
-        "image": "0.0051456",
+        "completion": "0.0000012",
+        "image": "0.001734",
         "internal_reasoning": "0",
-        "prompt": "0.0000008",
+        "prompt": "0.0000012",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed"
+      ],
       "top_provider": {
-        "context_length": 4096,
+        "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 4096
+        "max_completion_tokens": 2048
       }
     },
     {
@@ -4413,9 +6210,10 @@
         ],
         "tokenizer": "Llama3"
       },
-      "context_length": 128000,
+      "context_length": 131072,
       "created": 1733506137,
       "description": "The Meta Llama 3.3 multilingual large language model (LLM) is a pretrained and instruction tuned generative model in 70B (text in/text out). The Llama 3.3 instruction tuned text only model is optimized for multilingual dialogue use cases and outperforms many of the available open source and closed chat models on common industry benchmarks.\n\nSupported languages: English, German, French, Italian, Portuguese, Hindi, Spanish, and Thai.\n\n[Model Card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/MODEL_CARD.md)",
+      "hugging_face_id": "meta-llama/Llama-3.3-70B-Instruct",
       "id": "meta-llama/llama-3.3-70b-instruct",
       "name": "Meta: Llama 3.3 70B Instruct",
       "per_request_limits": null,
@@ -4423,12 +6221,31 @@
         "completion": "0.00000025",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000001",
+        "prompt": "0.00000007",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "structured_outputs"
+      ],
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 131072,
         "is_moderated": false,
         "max_completion_tokens": 16384
       }
@@ -4445,9 +6262,10 @@
         ],
         "tokenizer": "Llama3"
       },
-      "context_length": 8000,
+      "context_length": 131072,
       "created": 1733506137,
       "description": "The Meta Llama 3.3 multilingual large language model (LLM) is a pretrained and instruction tuned generative model in 70B (text in/text out). The Llama 3.3 instruction tuned text only model is optimized for multilingual dialogue use cases and outperforms many of the available open source and closed chat models on common industry benchmarks.\n\nSupported languages: English, German, French, Italian, Portuguese, Hindi, Spanish, and Thai.\n\n[Model Card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/MODEL_CARD.md)",
+      "hugging_face_id": "meta-llama/Llama-3.3-70B-Instruct",
       "id": "meta-llama/llama-3.3-70b-instruct:free",
       "name": "Meta: Llama 3.3 70B Instruct (free)",
       "per_request_limits": null,
@@ -4459,10 +6277,70 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "tools",
+        "tool_choice",
+        "repetition_penalty",
+        "top_k",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
-        "context_length": 8000,
+        "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8000
+        "max_completion_tokens": 2048
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Llama3"
+      },
+      "context_length": 128000,
+      "created": 1747230154,
+      "description": "A lightweight and ultra-fast variant of Llama 3.3 70B, for use when quick response times are needed most.",
+      "hugging_face_id": "",
+      "id": "meta-llama/llama-3.3-8b-instruct:free",
+      "name": "Meta: Llama 3.3 8B Instruct (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "structured_outputs",
+        "response_format",
+        "repetition_penalty",
+        "top_k"
+      ],
+      "top_provider": {
+        "context_length": 128000,
+        "is_moderated": false,
+        "max_completion_tokens": 4028
       }
     },
     {
@@ -4476,11 +6354,12 @@
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Other"
+        "tokenizer": "Llama4"
       },
       "context_length": 1048576,
       "created": 1743881822,
       "description": "Llama 4 Maverick 17B Instruct (128E) is a high-capacity multimodal language model from Meta, built on a mixture-of-experts (MoE) architecture with 128 experts and 17 billion active parameters per forward pass (400B total). It supports multilingual text and image input, and produces multilingual text and code output across 12 supported languages. Optimized for vision-language tasks, Maverick is instruction-tuned for assistant-like behavior, image reasoning, and general-purpose multimodal interaction.\n\nMaverick features early fusion for native multimodality and a 1 million token context window. It was trained on a curated mixture of public, licensed, and Meta-platform data, covering ~22 trillion tokens, with a knowledge cutoff in August 2024. Released on April 5, 2025 under the Llama 4 Community License, Maverick is suited for research and commercial applications requiring advanced multimodal understanding and high model throughput.",
+      "hugging_face_id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
       "id": "meta-llama/llama-4-maverick",
       "name": "Meta: Llama 4 Maverick",
       "per_request_limits": null,
@@ -4488,14 +6367,33 @@
         "completion": "0.0000006",
         "image": "0.0006684",
         "internal_reasoning": "0",
-        "prompt": "0.00000018",
+        "prompt": "0.00000016",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "tools",
+        "tool_choice",
+        "structured_outputs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 1048576,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4509,11 +6407,12 @@
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Other"
+        "tokenizer": "Llama4"
       },
-      "context_length": 256000,
+      "context_length": 128000,
       "created": 1743881822,
       "description": "Llama 4 Maverick 17B Instruct (128E) is a high-capacity multimodal language model from Meta, built on a mixture-of-experts (MoE) architecture with 128 experts and 17 billion active parameters per forward pass (400B total). It supports multilingual text and image input, and produces multilingual text and code output across 12 supported languages. Optimized for vision-language tasks, Maverick is instruction-tuned for assistant-like behavior, image reasoning, and general-purpose multimodal interaction.\n\nMaverick features early fusion for native multimodality and a 1 million token context window. It was trained on a curated mixture of public, licensed, and Meta-platform data, covering ~22 trillion tokens, with a knowledge cutoff in August 2024. Released on April 5, 2025 under the Llama 4 Community License, Maverick is suited for research and commercial applications requiring advanced multimodal understanding and high model throughput.",
+      "hugging_face_id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
       "id": "meta-llama/llama-4-maverick:free",
       "name": "Meta: Llama 4 Maverick (free)",
       "per_request_limits": null,
@@ -4525,8 +6424,27 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "structured_outputs",
+        "response_format",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs",
+        "tools",
+        "tool_choice"
+      ],
       "top_provider": {
-        "context_length": 256000,
+        "context_length": 128000,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -4542,26 +6460,46 @@
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Other"
+        "tokenizer": "Llama4"
       },
-      "context_length": 327680,
+      "context_length": 1048576,
       "created": 1743881519,
       "description": "Llama 4 Scout 17B Instruct (16E) is a mixture-of-experts (MoE) language model developed by Meta, activating 17 billion parameters out of a total of 109B. It supports native multimodal input (text and image) and multilingual output (text and code) across 12 supported languages. Designed for assistant-style interaction and visual reasoning, Scout uses 16 experts per forward pass and features a context length of 10 million tokens, with a training corpus of ~40 trillion tokens.\n\nBuilt for high efficiency and local or commercial deployment, Llama 4 Scout incorporates early fusion for seamless modality integration. It is instruction-tuned for use in multilingual chat, captioning, and image understanding tasks. Released under the Llama 4 Community License, it was last trained on data up to August 2024 and launched publicly on April 5, 2025.",
+      "hugging_face_id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
       "id": "meta-llama/llama-4-scout",
       "name": "Meta: Llama 4 Scout",
       "per_request_limits": null,
       "pricing": {
         "completion": "0.0000003",
-        "image": "0.0003342",
+        "image": "0",
         "internal_reasoning": "0",
         "prompt": "0.00000008",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "response_format",
+        "tools",
+        "tool_choice",
+        "structured_outputs",
+        "repetition_penalty",
+        "top_k",
+        "top_logprobs",
+        "logprobs",
+        "logit_bias",
+        "min_p"
+      ],
       "top_provider": {
-        "context_length": 327680,
+        "context_length": 1048576,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 1048576
       }
     },
     {
@@ -4575,11 +6513,12 @@
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Other"
+        "tokenizer": "Llama4"
       },
-      "context_length": 512000,
+      "context_length": 200000,
       "created": 1743881519,
       "description": "Llama 4 Scout 17B Instruct (16E) is a mixture-of-experts (MoE) language model developed by Meta, activating 17 billion parameters out of a total of 109B. It supports native multimodal input (text and image) and multilingual output (text and code) across 12 supported languages. Designed for assistant-style interaction and visual reasoning, Scout uses 16 experts per forward pass and features a context length of 10 million tokens, with a training corpus of ~40 trillion tokens.\n\nBuilt for high efficiency and local or commercial deployment, Llama 4 Scout incorporates early fusion for seamless modality integration. It is instruction-tuned for use in multilingual chat, captioning, and image understanding tasks. Released under the Llama 4 Community License, it was last trained on data up to August 2024 and launched publicly on April 5, 2025.",
+      "hugging_face_id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
       "id": "meta-llama/llama-4-scout:free",
       "name": "Meta: Llama 4 Scout (free)",
       "per_request_limits": null,
@@ -4591,8 +6530,77 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "structured_outputs",
+        "response_format",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs",
+        "tools",
+        "tool_choice"
+      ],
       "top_provider": {
-        "context_length": 512000,
+        "context_length": 200000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 163840,
+      "created": 1745975193,
+      "description": "Llama Guard 4 is a Llama 4 Scout-derived multimodal pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM—generating text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated.\n\nLlama Guard 4 was aligned to safeguard against the standardized MLCommons hazards taxonomy and designed to support multimodal Llama 4 capabilities. Specifically, it combines features from previous Llama Guard models, providing content moderation for English and multiple supported languages, along with enhanced capabilities to handle mixed text-and-image prompts, including multiple images. Additionally, Llama Guard 4 is integrated into the Llama Moderations API, extending robust safety classification to text and images.",
+      "hugging_face_id": "meta-llama/Llama-Guard-4-12B",
+      "id": "meta-llama/llama-guard-4-12b",
+      "name": "Meta: Llama Guard 4 12B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000005",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000005",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "top_logprobs",
+        "logprobs"
+      ],
+      "top_provider": {
+        "context_length": 163840,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -4612,6 +6620,7 @@
       "context_length": 8192,
       "created": 1715558400,
       "description": "This safeguard model has 8B parameters and is based on the Llama 3 family. Just like is predecessor, [LlamaGuard 1](https://huggingface.co/meta-llama/LlamaGuard-7b), it can do both prompt and response classification.\n\nLlamaGuard 2 acts as a normal LLM would, generating text that indicates whether the given input/output is safe/unsafe. If deemed unsafe, it will also share the content categories violated.\n\nFor best results, please use raw prompt input or the `/completions` endpoint, instead of the chat API.\n\nIt has demonstrated strong performance compared to leading closed-source models in human evaluations.\n\nTo read more about the model release, [click here](https://ai.meta.com/blog/meta-llama-3/). Usage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "meta-llama/Meta-Llama-Guard-2-8B",
       "id": "meta-llama/llama-guard-2-8b",
       "name": "Meta: LlamaGuard 2 8B",
       "per_request_limits": null,
@@ -4623,8 +6632,71 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 8192,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "deepseek-r1",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "DeepSeek"
+      },
+      "context_length": 163840,
+      "created": 1745194100,
+      "description": "MAI-DS-R1 is a post-trained variant of DeepSeek-R1 developed by the Microsoft AI team to improve the model’s responsiveness on previously blocked topics while enhancing its safety profile. Built on top of DeepSeek-R1’s reasoning foundation, it integrates 110k examples from the Tulu-3 SFT dataset and 350k internally curated multilingual safety-alignment samples. The model retains strong reasoning, coding, and problem-solving capabilities, while unblocking a wide range of prompts previously restricted in R1.\n\nMAI-DS-R1 demonstrates improved performance on harm mitigation benchmarks and maintains competitive results across general reasoning tasks. It surpasses R1-1776 in satisfaction metrics for blocked queries and reduces leakage in harmful content categories. The model is based on a transformer MoE architecture and is suitable for general-purpose use cases, excluding high-stakes domains such as legal, medical, or autonomous systems.",
+      "hugging_face_id": "microsoft/MAI-DS-R1",
+      "id": "microsoft/mai-ds-r1:free",
+      "name": "Microsoft: MAI DS R1 (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 163840,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -4644,6 +6716,7 @@
       "context_length": 16384,
       "created": 1736489872,
       "description": "[Microsoft Research](/microsoft) Phi-4 is designed to perform well in complex reasoning tasks and can operate efficiently in situations with limited memory or where quick responses are needed. \n\nAt 14 billion parameters, it was trained on a mix of high-quality synthetic datasets, data from curated websites, and academic materials. It has undergone careful improvement to follow instructions accurately and maintain strong safety standards. It works best with English language inputs.\n\nFor more information, please see [Phi-4 Technical Report](https://arxiv.org/pdf/2412.08905)\n",
+      "hugging_face_id": "microsoft/phi-4",
       "id": "microsoft/phi-4",
       "name": "Microsoft: Phi 4",
       "per_request_limits": null,
@@ -4655,10 +6728,26 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "repetition_penalty",
+        "response_format",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -4677,6 +6766,7 @@
       "context_length": 131072,
       "created": 1741396284,
       "description": "Phi-4 Multimodal Instruct is a versatile 5.6B parameter foundation model that combines advanced reasoning and instruction-following capabilities across both text and visual inputs, providing accurate text outputs. The unified architecture enables efficient, low-latency inference, suitable for edge and mobile deployments. Phi-4 Multimodal Instruct supports text inputs in multiple languages including Arabic, Chinese, English, French, German, Japanese, Spanish, and more, with visual input optimized primarily for English. It delivers impressive performance on multimodal tasks involving mathematical, scientific, and document reasoning, providing developers and enterprises a powerful yet compact model for sophisticated interactive applications. For more information, see the [Phi-4 Multimodal blog post](https://azure.microsoft.com/en-us/blog/empowering-innovation-the-next-generation-of-the-phi-family/).\n",
+      "hugging_face_id": "microsoft/Phi-4-multimodal-instruct",
       "id": "microsoft/phi-4-multimodal-instruct",
       "name": "Microsoft: Phi 4 Multimodal Instruct",
       "per_request_limits": null,
@@ -4688,6 +6778,215 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1746121275,
+      "description": "Phi-4-reasoning is a 14B parameter dense decoder-only transformer developed by Microsoft, fine-tuned from Phi-4 to enhance complex reasoning capabilities. It uses a combination of supervised fine-tuning on chain-of-thought traces and reinforcement learning, targeting math, science, and code reasoning tasks. With a 32k context window and high inference efficiency, it is optimized for structured responses in a two-part format: reasoning trace followed by a final solution.\n\nThe model achieves strong results on specialized benchmarks such as AIME, OmniMath, and LiveCodeBench, outperforming many larger models in structured reasoning tasks. It is released under the MIT license and intended for use in latency-constrained, English-only environments requiring reliable step-by-step logic. Recommended usage includes ChatML prompts and structured reasoning format for best results.",
+      "hugging_face_id": "microsoft/Phi-4-reasoning",
+      "id": "microsoft/phi-4-reasoning:free",
+      "name": "Microsoft: Phi 4 Reasoning (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1746130961,
+      "description": "Phi-4-reasoning-plus is an enhanced 14B parameter model from Microsoft, fine-tuned from Phi-4 with additional reinforcement learning to boost accuracy on math, science, and code reasoning tasks. It uses the same dense decoder-only transformer architecture as Phi-4, but generates longer, more comprehensive outputs structured into a step-by-step reasoning trace and final answer.\n\nWhile it offers improved benchmark scores over Phi-4-reasoning across tasks like AIME, OmniMath, and HumanEvalPlus, its responses are typically ~50% longer, resulting in higher latency. Designed for English-only applications, it is well-suited for structured reasoning workflows where output quality takes priority over response speed.",
+      "hugging_face_id": "microsoft/Phi-4-reasoning-plus",
+      "id": "microsoft/phi-4-reasoning-plus",
+      "name": "Microsoft: Phi 4 Reasoning Plus",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000035",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000007",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1746130961,
+      "description": "Phi-4-reasoning-plus is an enhanced 14B parameter model from Microsoft, fine-tuned from Phi-4 with additional reinforcement learning to boost accuracy on math, science, and code reasoning tasks. It uses the same dense decoder-only transformer architecture as Phi-4, but generates longer, more comprehensive outputs structured into a step-by-step reasoning trace and final answer.\n\nWhile it offers improved benchmark scores over Phi-4-reasoning across tasks like AIME, OmniMath, and HumanEvalPlus, its responses are typically ~50% longer, resulting in higher latency. Designed for English-only applications, it is well-suited for structured reasoning workflows where output quality takes priority over response speed.",
+      "hugging_face_id": "microsoft/Phi-4-reasoning-plus",
+      "id": "microsoft/phi-4-reasoning-plus:free",
+      "name": "Microsoft: Phi 4 Reasoning Plus (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "phi3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 131072,
+      "created": 1716508800,
+      "description": "Phi-3 128K Medium is a powerful 14-billion parameter model designed for advanced language understanding, reasoning, and instruction following. Optimized through supervised fine-tuning and preference adjustments, it excels in tasks involving common sense, mathematics, logical reasoning, and code processing.\n\nAt time of release, Phi-3 Medium demonstrated state-of-the-art performance among lightweight models. In the MMLU-Pro eval, the model even comes close to a Llama3 70B level of performance.\n\nFor 4k context length, try [Phi-3 Medium 4K](/models/microsoft/phi-3-medium-4k-instruct).",
+      "hugging_face_id": "microsoft/Phi-3-medium-128k-instruct",
+      "id": "microsoft/phi-3-medium-128k-instruct",
+      "name": "Microsoft: Phi-3 Medium 128K Instruct",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000003",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000001",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -4707,40 +7006,9 @@
         "tokenizer": "Other"
       },
       "context_length": 128000,
-      "created": 1716508800,
-      "description": "Phi-3 128K Medium is a powerful 14-billion parameter model designed for advanced language understanding, reasoning, and instruction following. Optimized through supervised fine-tuning and preference adjustments, it excels in tasks involving common sense, mathematics, logical reasoning, and code processing.\n\nAt time of release, Phi-3 Medium demonstrated state-of-the-art performance among lightweight models. In the MMLU-Pro eval, the model even comes close to a Llama3 70B level of performance.\n\nFor 4k context length, try [Phi-3 Medium 4K](/models/microsoft/phi-3-medium-4k-instruct).",
-      "id": "microsoft/phi-3-medium-128k-instruct",
-      "name": "Microsoft: Phi-3 Medium 128K Instruct",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000001",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.000001",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "phi3",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 128000,
       "created": 1716681600,
       "description": "Phi-3 Mini is a powerful 3.8B parameter model designed for advanced language understanding, reasoning, and instruction following. Optimized through supervised fine-tuning and preference adjustments, it excels in tasks involving common sense, mathematics, logical reasoning, and code processing.\n\nAt time of release, Phi-3 Medium demonstrated state-of-the-art performance among lightweight models. This model is static, trained on an offline dataset with an October 2023 cutoff date.",
+      "hugging_face_id": "microsoft/Phi-3-mini-128k-instruct",
       "id": "microsoft/phi-3-mini-128k-instruct",
       "name": "Microsoft: Phi-3 Mini 128K Instruct",
       "per_request_limits": null,
@@ -4752,6 +7020,13 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -4770,22 +7045,38 @@
         ],
         "tokenizer": "Other"
       },
-      "context_length": 128000,
+      "context_length": 131072,
       "created": 1724198400,
       "description": "Phi-3.5 models are lightweight, state-of-the-art open models. These models were trained with Phi-3 datasets that include both synthetic data and the filtered, publicly available websites data, with a focus on high quality and reasoning-dense properties. Phi-3.5 Mini uses 3.8B parameters, and is a dense decoder-only transformer model using the same tokenizer as [Phi-3 Mini](/models/microsoft/phi-3-mini-128k-instruct).\n\nThe models underwent a rigorous enhancement process, incorporating both supervised fine-tuning, proximal policy optimization, and direct preference optimization to ensure precise instruction adherence and robust safety measures. When assessed against benchmarks that test common sense, language understanding, math, code, long context and logical reasoning, Phi-3.5 models showcased robust and state-of-the-art performance among models with less than 13 billion parameters.",
+      "hugging_face_id": "microsoft/Phi-3.5-mini-instruct",
       "id": "microsoft/phi-3.5-mini-128k-instruct",
       "name": "Microsoft: Phi-3.5 Mini 128K Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000001",
+        "completion": "0.00000009",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000001",
+        "prompt": "0.00000003",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 131072,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -4805,6 +7096,7 @@
       "context_length": 4096,
       "created": 1711065600,
       "description": "A merge with a complex family tree, this model was crafted for roleplaying and storytelling. Midnight Rose is a successor to Rogue Rose and Aurora Nights and improves upon them both. It wants to produce lengthy output by default and is the best creative writing merge produced so far by sophosympatheia.\n\nDescending from earlier versions of Midnight Rose and [Wizard Tulu Dolphin 70B](https://huggingface.co/sophosympatheia/Wizard-Tulu-Dolphin-70B-v1.0), it inherits the best qualities of each.",
+      "hugging_face_id": "sophosympatheia/Midnight-Rose-70B-v2.0.3",
       "id": "sophosympatheia/midnight-rose-70b",
       "name": "Midnight Rose 70B",
       "per_request_limits": null,
@@ -4816,6 +7108,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
@@ -4838,6 +7143,7 @@
       "context_length": 1000192,
       "created": 1736915462,
       "description": "MiniMax-01 is a combines MiniMax-Text-01 for text generation and MiniMax-VL-01 for image understanding. It has 456 billion parameters, with 45.9 billion parameters activated per inference, and can handle a context of up to 4 million tokens.\n\nThe text model adopts a hybrid architecture that combines Lightning Attention, Softmax Attention, and Mixture-of-Experts (MoE). The image model adopts the “ViT-MLP-LLM” framework and is trained on top of the text model.\n\nTo read more about the release, see: https://www.minimaxi.com/en/news/minimax-01-series-2",
+      "hugging_face_id": "MiniMaxAI/MiniMax-Text-01",
       "id": "minimax/minimax-01",
       "name": "MiniMax: MiniMax-01",
       "per_request_limits": null,
@@ -4849,6 +7155,11 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p"
+      ],
       "top_provider": {
         "context_length": 1000192,
         "is_moderated": false,
@@ -4870,6 +7181,7 @@
       "context_length": 128000,
       "created": 1708905600,
       "description": "This is Mistral AI's flagship model, Mistral Large 2 (version `mistral-large-2407`). It's a proprietary weights-available model and excels at reasoning, code, JSON, chat, and more. Read the launch announcement [here](https://mistral.ai/news/mistral-large-2407/).\n\nIt supports dozens of languages including French, German, Spanish, Italian, Portuguese, Arabic, Hindi, Russian, Chinese, Japanese, and Korean, along with 80+ coding languages including Python, Java, C, C++, JavaScript, and Bash. Its long context window allows precise information recall from large documents.",
+      "hugging_face_id": null,
       "id": "mistralai/mistral-large",
       "name": "Mistral Large",
       "per_request_limits": null,
@@ -4881,6 +7193,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "response_format",
+        "stop",
+        "seed",
+        "frequency_penalty",
+        "presence_penalty",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -4902,6 +7227,7 @@
       "context_length": 131072,
       "created": 1731978415,
       "description": "This is Mistral AI's flagship model, Mistral Large 2 (version mistral-large-2407). It's a proprietary weights-available model and excels at reasoning, code, JSON, chat, and more. Read the launch announcement [here](https://mistral.ai/news/mistral-large-2407/).\n\nIt supports dozens of languages including French, German, Spanish, Italian, Portuguese, Arabic, Hindi, Russian, Chinese, Japanese, and Korean, along with 80+ coding languages including Python, Java, C, C++, JavaScript, and Bash. Its long context window allows precise information recall from large documents.\n",
+      "hugging_face_id": "",
       "id": "mistralai/mistral-large-2407",
       "name": "Mistral Large 2407",
       "per_request_limits": null,
@@ -4913,6 +7239,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -4934,6 +7273,7 @@
       "context_length": 131072,
       "created": 1731978685,
       "description": "Mistral Large 2 2411 is an update of [Mistral Large 2](/mistralai/mistral-large) released together with [Pixtral Large 2411](/mistralai/pixtral-large-2411)\n\nIt provides a significant upgrade on the previous [Mistral Large 24.07](/mistralai/mistral-large-2407), with notable improvements in long context understanding, a new system prompt, and more accurate function calling.",
+      "hugging_face_id": "",
       "id": "mistralai/mistral-large-2411",
       "name": "Mistral Large 2411",
       "per_request_limits": null,
@@ -4945,6 +7285,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -4966,6 +7319,7 @@
       "context_length": 32768,
       "created": 1704844800,
       "description": "This is Mistral AI's closed-source, medium-sided model. It's powered by a closed-source prototype and excels at reasoning, code, JSON, chat, and more. In benchmarks, it compares with many of the flagship models of other companies.",
+      "hugging_face_id": null,
       "id": "mistralai/mistral-medium",
       "name": "Mistral Medium",
       "per_request_limits": null,
@@ -4977,6 +7331,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -4998,6 +7365,7 @@
       "context_length": 16384,
       "created": 1722556800,
       "description": "A specialized story writing and roleplaying model based on Mistral's NeMo 12B Instruct. Fine-tuned on curated datasets including Reddit Writing Prompts and Opus Instruct 25K.\n\nThis model excels at creative writing, offering improved NSFW capabilities, with smarter and more active narration. It demonstrates remarkable versatility in both SFW and NSFW scenarios, with strong Out of Character (OOC) steering capabilities, allowing fine-tuned control over narrative direction and character behavior.\n\nCheck out the model's [HuggingFace page](https://huggingface.co/nothingiisreal/MN-12B-Celeste-V1.9) for details on what parameters and prompts work best!",
+      "hugging_face_id": "nothingiisreal/MN-12B-Celeste-V1.9",
       "id": "nothingiisreal/mn-celeste-12b",
       "name": "Mistral Nemo 12B Celeste",
       "per_request_limits": null,
@@ -5009,6 +7377,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -5030,6 +7410,7 @@
       "context_length": 32768,
       "created": 1704844800,
       "description": "With 22 billion parameters, Mistral Small v24.09 offers a convenient mid-point between (Mistral NeMo 12B)[/mistralai/mistral-nemo] and (Mistral Large 2)[/mistralai/mistral-large], providing a cost-effective solution that can be deployed across various platforms and environments. It has better reasoning, exhibits more capabilities, can produce and reason about code, and is multiligual, supporting English, French, German, Italian, and Spanish.",
+      "hugging_face_id": null,
       "id": "mistralai/mistral-small",
       "name": "Mistral Small",
       "per_request_limits": null,
@@ -5041,6 +7422,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -5062,6 +7456,7 @@
       "context_length": 32768,
       "created": 1704844800,
       "description": "Note: This model is being deprecated. Recommended replacement is the newer [Ministral 8B](/mistral/ministral-8b)\n\nThis model is currently powered by Mistral-7B-v0.2, and incorporates a \"better\" fine-tuning than [Mistral 7B](/models/mistralai/mistral-7b-instruct-v0.1), inspired by community work. It's best used for large batch processing tasks where cost is a significant factor but reasoning capabilities are not crucial.",
+      "hugging_face_id": null,
       "id": "mistralai/mistral-tiny",
       "name": "Mistral Tiny",
       "per_request_limits": null,
@@ -5073,6 +7468,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -5094,6 +7502,7 @@
       "context_length": 262144,
       "created": 1736895522,
       "description": "[Mistral](/mistralai)'s cutting-edge language model for coding. Codestral specializes in low-latency, high-frequency tasks such as fill-in-the-middle (FIM), code correction and test generation. \n\nLearn more on their blog post: https://mistral.ai/news/codestral-2501/",
+      "hugging_face_id": "",
       "id": "mistralai/codestral-2501",
       "name": "Mistral: Codestral 2501",
       "per_request_limits": null,
@@ -5105,6 +7514,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 262144,
         "is_moderated": false,
@@ -5126,6 +7548,7 @@
       "context_length": 262144,
       "created": 1721347200,
       "description": "A 7.3B parameter Mamba-based model designed for code and reasoning tasks.\n\n- Linear time inference, allowing for theoretically infinite sequence lengths\n- 256k token context window\n- Optimized for quick responses, especially beneficial for code productivity\n- Performs comparably to state-of-the-art transformer models in code and reasoning tasks\n- Available under the Apache 2.0 license for free use, modification, and distribution",
+      "hugging_face_id": "mistralai/mamba-codestral-7B-v0.1",
       "id": "mistralai/codestral-mamba",
       "name": "Mistral: Codestral Mamba",
       "per_request_limits": null,
@@ -5137,6 +7560,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 262144,
         "is_moderated": false,
@@ -5153,22 +7588,86 @@
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Mistral"
+        "tokenizer": "Other"
       },
       "context_length": 131072,
-      "created": 1729123200,
-      "description": "Ministral 3B is a 3B parameter model optimized for on-device and edge computing. It excels in knowledge, commonsense reasoning, and function-calling, outperforming larger models like Mistral 7B on most benchmarks. Supporting up to 128k context length, it’s ideal for orchestrating agentic workflows and specialist tasks with efficient inference.",
-      "id": "mistralai/ministral-3b",
-      "name": "Mistral: Ministral 3B",
+      "created": 1747837379,
+      "description": "Devstral-Small-2505 is a 24B parameter agentic LLM fine-tuned from Mistral-Small-3.1, jointly developed by Mistral AI and All Hands AI for advanced software engineering tasks. It is optimized for codebase exploration, multi-file editing, and integration into coding agents, achieving state-of-the-art results on SWE-Bench Verified (46.8%).\n\nDevstral supports a 128k context window and uses a custom Tekken tokenizer. It is text-only, with the vision encoder removed, and is suitable for local deployment on high-end consumer hardware (e.g., RTX 4090, 32GB RAM Macs). Devstral is best used in agentic workflows via the OpenHands scaffold and is compatible with inference frameworks like vLLM, Transformers, and Ollama. It is released under the Apache 2.0 license.",
+      "hugging_face_id": "mistralai/Devstral-Small-2505",
+      "id": "mistralai/devstral-small",
+      "name": "Mistral: Devstral Small",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000004",
+        "completion": "0.0000001",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000004",
+        "prompt": "0.00000007",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed",
+        "repetition_penalty",
+        "top_k"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 131072,
+      "created": 1747837379,
+      "description": "Devstral-Small-2505 is a 24B parameter agentic LLM fine-tuned from Mistral-Small-3.1, jointly developed by Mistral AI and All Hands AI for advanced software engineering tasks. It is optimized for codebase exploration, multi-file editing, and integration into coding agents, achieving state-of-the-art results on SWE-Bench Verified (46.8%).\n\nDevstral supports a 128k context window and uses a custom Tekken tokenizer. It is text-only, with the vision encoder removed, and is suitable for local deployment on high-end consumer hardware (e.g., RTX 4090, 32GB RAM Macs). Devstral is best used in agentic workflows via the OpenHands scaffold and is compatible with inference frameworks like vLLM, Transformers, and Ollama. It is released under the Apache 2.0 license.",
+      "hugging_face_id": "mistralai/Devstral-Small-2505",
+      "id": "mistralai/devstral-small:free",
+      "name": "Mistral: Devstral Small (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -5188,19 +7687,33 @@
         "tokenizer": "Mistral"
       },
       "context_length": 131072,
-      "created": 1743430021,
-      "description": "Ministral 8B is a state-of-the-art language model optimized for on-device and edge computing. Designed for efficiency in knowledge-intensive tasks, commonsense reasoning, and function-calling, it features a specialized interleaved sliding-window attention mechanism, enabling faster and more memory-efficient inference. Ministral 8B excels in local, low-latency applications such as offline translation, smart assistants, autonomous robotics, and local analytics.\n\nThe model supports up to 128k context length and can function as a performant intermediary in multi-step agentic workflows, efficiently handling tasks like input parsing, API calls, and task routing. It consistently outperforms comparable models like Mistral 7B across benchmarks, making it particularly suitable for compute-efficient, privacy-focused scenarios.",
-      "id": "mistral/ministral-8b",
-      "name": "Mistral: Ministral 8B",
+      "created": 1729123200,
+      "description": "Ministral 3B is a 3B parameter model optimized for on-device and edge computing. It excels in knowledge, commonsense reasoning, and function-calling, outperforming larger models like Mistral 7B on most benchmarks. Supporting up to 128k context length, it’s ideal for orchestrating agentic workflows and specialist tasks with efficient inference.",
+      "hugging_face_id": null,
+      "id": "mistralai/ministral-3b",
+      "name": "Mistral: Ministral 3B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000001",
+        "completion": "0.00000004",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000001",
+        "prompt": "0.00000004",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -5222,6 +7735,7 @@
       "context_length": 128000,
       "created": 1729123200,
       "description": "Ministral 8B is an 8B parameter model featuring a unique interleaved sliding-window attention pattern for faster, memory-efficient inference. Designed for edge use cases, it supports up to 128k context length and excels in knowledge and reasoning tasks. It outperforms peers in the sub-10B category, making it perfect for low-latency, privacy-first applications.",
+      "hugging_face_id": null,
       "id": "mistralai/ministral-8b",
       "name": "Mistral: Ministral 8B",
       "per_request_limits": null,
@@ -5233,6 +7747,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -5254,21 +7781,40 @@
       "context_length": 32768,
       "created": 1716768000,
       "description": "A high-performing, industry-standard 7.3B parameter model, with optimizations for speed and context length.\n\n*Mistral 7B Instruct has multiple version variants, and this is intended to be the latest version.*",
+      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.3",
       "id": "mistralai/mistral-7b-instruct",
       "name": "Mistral: Mistral 7B Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000000055",
+        "completion": "0.000000054",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000003",
+        "prompt": "0.000000028",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "logprobs",
+        "tools",
+        "tool_choice",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -5286,6 +7832,7 @@
       "context_length": 32768,
       "created": 1716768000,
       "description": "A high-performing, industry-standard 7.3B parameter model, with optimizations for speed and context length.\n\n*Mistral 7B Instruct has multiple version variants, and this is intended to be the latest version.*",
+      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.3",
       "id": "mistralai/mistral-7b-instruct:free",
       "name": "Mistral: Mistral 7B Instruct (free)",
       "per_request_limits": null,
@@ -5297,10 +7844,25 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -5315,24 +7877,41 @@
         ],
         "tokenizer": "Mistral"
       },
-      "context_length": 32768,
+      "context_length": 2824,
       "created": 1695859200,
       "description": "A 7.3B parameter model that outperforms Llama 2 13B on all benchmarks, with optimizations for speed and context length.",
+      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.1",
       "id": "mistralai/mistral-7b-instruct-v0.1",
       "name": "Mistral: Mistral 7B Instruct v0.1",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000002",
+        "completion": "0.00000019",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000002",
+        "prompt": "0.00000011",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed"
+      ],
       "top_provider": {
-        "context_length": 32768,
+        "context_length": 2824,
         "is_moderated": false,
-        "max_completion_tokens": 2048
+        "max_completion_tokens": null
       }
     },
     {
@@ -5350,6 +7929,7 @@
       "context_length": 32768,
       "created": 1703721600,
       "description": "A high-performing, industry-standard 7.3B parameter model, with optimizations for speed and context length.\n\nAn improved version of [Mistral 7B Instruct](/modelsmistralai/mistral-7b-instruct-v0.1), with the following changes:\n\n- 32k context window (vs 8k context in v0.1)\n- Rope-theta = 1e6\n- No Sliding-Window Attention",
+      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.2",
       "id": "mistralai/mistral-7b-instruct-v0.2",
       "name": "Mistral: Mistral 7B Instruct v0.2",
       "per_request_limits": null,
@@ -5361,6 +7941,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -5382,21 +7975,87 @@
       "context_length": 32768,
       "created": 1716768000,
       "description": "A high-performing, industry-standard 7.3B parameter model, with optimizations for speed and context length.\n\nAn improved version of [Mistral 7B Instruct v0.2](/models/mistralai/mistral-7b-instruct-v0.2), with the following changes:\n\n- Extended vocabulary to 32768\n- Supports v3 Tokenizer\n- Supports function calling\n\nNOTE: Support for function calling depends on the provider.",
+      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.3",
       "id": "mistralai/mistral-7b-instruct-v0.3",
       "name": "Mistral: Mistral 7B Instruct v0.3",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000000055",
+        "completion": "0.000000054",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000004",
+        "prompt": "0.000000028",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "tools",
+        "tool_choice",
+        "logprobs",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Mistral"
+      },
+      "context_length": 131072,
+      "created": 1746627341,
+      "description": "Mistral Medium 3 is a high-performance enterprise-grade language model designed to deliver frontier-level capabilities at significantly reduced operational cost. It balances state-of-the-art reasoning and multimodal performance with 8× lower cost compared to traditional large models, making it suitable for scalable deployments across professional and industrial use cases.\n\nThe model excels in domains such as coding, STEM reasoning, and enterprise adaptation. It supports hybrid, on-prem, and in-VPC deployments and is optimized for integration into custom workflows. Mistral Medium 3 offers competitive accuracy relative to larger models like Claude Sonnet 3.5/3.7, Llama 4 Maverick, and Command R+, while maintaining broad compatibility across cloud environments.",
+      "hugging_face_id": "",
+      "id": "mistralai/mistral-medium-3",
+      "name": "Mistral: Mistral Medium 3",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.000002",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000004",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": null
       }
     },
     {
@@ -5414,21 +8073,41 @@
       "context_length": 131072,
       "created": 1721347200,
       "description": "A 12B parameter model with a 128k token context length built by Mistral in collaboration with NVIDIA.\n\nThe model is multilingual, supporting English, French, German, Spanish, Italian, Portuguese, Chinese, Japanese, Korean, Arabic, and Hindi.\n\nIt supports function calling and is released under the Apache 2.0 license.",
+      "hugging_face_id": "mistralai/Mistral-Nemo-Instruct-2407",
       "id": "mistralai/mistral-nemo",
       "name": "Mistral: Mistral Nemo",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000008",
+        "completion": "0.00000007",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.000000035",
+        "prompt": "0.00000002",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "structured_outputs",
+        "repetition_penalty",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 131072
       }
     },
     {
@@ -5443,9 +8122,10 @@
         ],
         "tokenizer": "Mistral"
       },
-      "context_length": 128000,
+      "context_length": 131072,
       "created": 1721347200,
       "description": "A 12B parameter model with a 128k token context length built by Mistral in collaboration with NVIDIA.\n\nThe model is multilingual, supporting English, French, German, Spanish, Italian, Portuguese, Chinese, Japanese, Korean, Arabic, and Hindi.\n\nIt supports function calling and is released under the Apache 2.0 license.",
+      "hugging_face_id": "mistralai/Mistral-Nemo-Instruct-2407",
       "id": "mistralai/mistral-nemo:free",
       "name": "Mistral: Mistral Nemo (free)",
       "per_request_limits": null,
@@ -5457,8 +8137,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 131072,
         "is_moderated": false,
         "max_completion_tokens": 128000
       }
@@ -5478,21 +8173,40 @@
       "context_length": 32768,
       "created": 1738255409,
       "description": "Mistral Small 3 is a 24B-parameter language model optimized for low-latency performance across common AI tasks. Released under the Apache 2.0 license, it features both pre-trained and instruction-tuned versions designed for efficient local deployment.\n\nThe model achieves 81% accuracy on the MMLU benchmark and performs competitively with larger models like Llama 3.3 70B and Qwen 32B, while operating at three times the speed on equivalent hardware. [Read the blog post about the model here.](https://mistral.ai/news/mistral-small-3/)",
+      "hugging_face_id": "mistralai/Mistral-Small-24B-Instruct-2501",
       "id": "mistralai/mistral-small-24b-instruct-2501",
       "name": "Mistral: Mistral Small 3",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000014",
+        "completion": "0.00000012",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000007",
+        "prompt": "0.00000006",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p",
+        "tools",
+        "tool_choice",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -5510,6 +8224,7 @@
       "context_length": 32768,
       "created": 1738255409,
       "description": "Mistral Small 3 is a 24B-parameter language model optimized for low-latency performance across common AI tasks. Released under the Apache 2.0 license, it features both pre-trained and instruction-tuned versions designed for efficient local deployment.\n\nThe model achieves 81% accuracy on the MMLU benchmark and performs competitively with larger models like Llama 3.3 70B and Qwen 32B, while operating at three times the speed on equivalent hardware. [Read the blog post about the model here.](https://mistral.ai/news/mistral-small-3/)",
+      "hugging_face_id": "mistralai/Mistral-Small-24B-Instruct-2501",
       "id": "mistralai/mistral-small-24b-instruct-2501:free",
       "name": "Mistral: Mistral Small 3 (free)",
       "per_request_limits": null,
@@ -5521,6 +8236,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -5540,22 +8270,41 @@
         ],
         "tokenizer": "Mistral"
       },
-      "context_length": 32768,
+      "context_length": 131072,
       "created": 1742238937,
       "description": "Mistral Small 3.1 24B Instruct is an upgraded variant of Mistral Small 3 (2501), featuring 24 billion parameters with advanced multimodal capabilities. It provides state-of-the-art performance in text-based reasoning and vision tasks, including image analysis, programming, mathematical reasoning, and multilingual support across dozens of languages. Equipped with an extensive 128k token context window and optimized for efficient local inference, it supports use cases such as conversational agents, function calling, long-document comprehension, and privacy-sensitive deployments.",
+      "hugging_face_id": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
       "id": "mistralai/mistral-small-3.1-24b-instruct",
       "name": "Mistral: Mistral Small 3.1 24B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000003",
-        "image": "0.0009264",
+        "completion": "0.00000015",
+        "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000001",
+        "prompt": "0.00000005",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "top_k",
+        "tools",
+        "tool_choice",
+        "stop",
+        "response_format",
+        "structured_outputs",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 32768,
+        "context_length": 131072,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -5576,6 +8325,7 @@
       "context_length": 96000,
       "created": 1742238937,
       "description": "Mistral Small 3.1 24B Instruct is an upgraded variant of Mistral Small 3 (2501), featuring 24 billion parameters with advanced multimodal capabilities. It provides state-of-the-art performance in text-based reasoning and vision tasks, including image analysis, programming, mathematical reasoning, and multilingual support across dozens of languages. Equipped with an extensive 128k token context window and optimized for efficient local inference, it supports use cases such as conversational agents, function calling, long-document comprehension, and privacy-sensitive deployments.",
+      "hugging_face_id": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
       "id": "mistralai/mistral-small-3.1-24b-instruct:free",
       "name": "Mistral: Mistral Small 3.1 24B (free)",
       "per_request_limits": null,
@@ -5587,6 +8337,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 96000,
         "is_moderated": false,
@@ -5608,17 +8375,36 @@
       "context_length": 65536,
       "created": 1713312000,
       "description": "Mistral's official instruct fine-tuned version of [Mixtral 8x22B](/models/mistralai/mixtral-8x22b). It uses 39B active parameters out of 141B, offering unparalleled cost efficiency for its size. Its strengths include:\n- strong math, coding, and reasoning\n- large context length (64k)\n- fluency in English, French, Italian, German, and Spanish\n\nSee benchmarks on the launch announcement [here](https://mistral.ai/news/mixtral-8x22b/).\n#moe",
+      "hugging_face_id": "mistralai/Mixtral-8x22B-Instruct-v0.1",
       "id": "mistralai/mixtral-8x22b-instruct",
       "name": "Mistral: Mixtral 8x22B Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000009",
+        "completion": "0.0000012",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000009",
+        "prompt": "0.0000004",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 65536,
         "is_moderated": false,
@@ -5640,6 +8426,7 @@
       "context_length": 32768,
       "created": 1702166400,
       "description": "Mixtral 8x7B Instruct is a pretrained generative Sparse Mixture of Experts, by Mistral AI, for chat and instruction use. Incorporates 8 experts (feed-forward networks) for a total of 47 billion parameters.\n\nInstruct model fine-tuned by Mistral. #moe",
+      "hugging_face_id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
       "id": "mistralai/mixtral-8x7b-instruct",
       "name": "Mistral: Mixtral 8x7B Instruct",
       "per_request_limits": null,
@@ -5647,14 +8434,32 @@
         "completion": "0.00000024",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000024",
+        "prompt": "0.00000008",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -5673,6 +8478,7 @@
       "context_length": 32768,
       "created": 1725926400,
       "description": "The first multi-modal, text+image-to-text model from Mistral AI. Its weights were launched via torrent: https://x.com/mistralai/status/1833758285167722836.",
+      "hugging_face_id": "mistralai/Pixtral-12B-2409",
       "id": "mistralai/pixtral-12b",
       "name": "Mistral: Pixtral 12B",
       "per_request_limits": null,
@@ -5684,6 +8490,25 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -5706,6 +8531,7 @@
       "context_length": 131072,
       "created": 1731977388,
       "description": "Pixtral Large is a 124B parameter, open-weight, multimodal model built on top of [Mistral Large 2](/mistralai/mistral-large-2411). The model is able to understand documents, charts and natural images.\n\nThe model is available under the Mistral Research License (MRL) for research and educational use, and the Mistral Commercial License for experimentation, testing, and production for commercial purposes.\n\n",
+      "hugging_face_id": "",
       "id": "mistralai/pixtral-large-2411",
       "name": "Mistral: Pixtral Large 2411",
       "per_request_limits": null,
@@ -5717,6 +8543,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -5738,6 +8577,7 @@
       "context_length": 32768,
       "created": 1739803239,
       "description": "Mistral Saba is a 24B-parameter language model specifically designed for the Middle East and South Asia, delivering accurate and contextually relevant responses while maintaining efficient performance. Trained on curated regional datasets, it supports multiple Indian-origin languages—including Tamil and Malayalam—alongside Arabic. This makes it a versatile option for a range of regional and multilingual applications. Read more at the blog post [here](https://mistral.ai/en/news/mistral-saba)",
+      "hugging_face_id": "",
       "id": "mistralai/mistral-saba",
       "name": "Mistral: Saba",
       "per_request_limits": null,
@@ -5749,6 +8589,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "response_format",
+        "structured_outputs",
+        "seed",
+        "top_logprobs",
+        "logprobs",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -5771,6 +8627,7 @@
       "context_length": 131072,
       "created": 1744304841,
       "description": "Kimi-VL is a lightweight Mixture-of-Experts vision-language model that activates only 2.8B parameters per step while delivering strong performance on multimodal reasoning and long-context tasks. The Kimi-VL-A3B-Thinking variant, fine-tuned with chain-of-thought and reinforcement learning, excels in math and visual reasoning benchmarks like MathVision, MMMU, and MathVista, rivaling much larger models such as Qwen2.5-VL-7B and Gemma-3-12B. It supports 128K context and high-resolution input via its MoonViT encoder.",
+      "hugging_face_id": "moonshotai/Kimi-VL-A3B-Thinking",
       "id": "moonshotai/kimi-vl-a3b-thinking:free",
       "name": "Moonshot AI: Kimi VL A3B Thinking (free)",
       "per_request_limits": null,
@@ -5782,6 +8639,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -5803,6 +8677,7 @@
       "context_length": 8192,
       "created": 1740719801,
       "description": "Moonlight-16B-A3B-Instruct is a 16B-parameter Mixture-of-Experts (MoE) language model developed by Moonshot AI. It is optimized for instruction-following tasks with 3B activated parameters per inference. The model advances the Pareto frontier in performance per FLOP across English, coding, math, and Chinese benchmarks. It outperforms comparable models like Llama3-3B and Deepseek-v2-Lite while maintaining efficient deployment capabilities through Hugging Face integration and compatibility with popular inference engines like vLLM12.",
+      "hugging_face_id": "moonshotai/Moonlight-16B-A3B-Instruct",
       "id": "moonshotai/moonlight-16b-a3b-instruct:free",
       "name": "Moonshot AI: Moonlight 16B A3B Instruct (free)",
       "per_request_limits": null,
@@ -5814,6 +8689,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -5835,6 +8725,7 @@
       "context_length": 4096,
       "created": 1688256000,
       "description": "One of the highest performing and most popular fine-tunes of Llama 2 13B, with rich descriptions and roleplay. #merge",
+      "hugging_face_id": "Gryphe/MythoMax-L2-13b",
       "id": "gryphe/mythomax-l2-13b",
       "name": "MythoMax 13B",
       "per_request_limits": null,
@@ -5846,6 +8737,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "top_k",
+        "stop",
+        "seed",
+        "min_p",
+        "logit_bias",
+        "response_format",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
@@ -5867,21 +8773,34 @@
       "context_length": 8192,
       "created": 1715817600,
       "description": "The NeverSleep team is back, with a Llama 3 70B finetune trained on their curated roleplay data. Striking a balance between eRP and RP, Lumimaid was designed to be serious, yet uncensored when necessary.\n\nTo enhance it's overall intelligence and chat capability, roughly 40% of the training data was not roleplay. This provides a breadth of knowledge to access, while still keeping roleplay as the primary strength.\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "NeverSleep/Llama-3-Lumimaid-70B-v0.1",
       "id": "neversleep/llama-3-lumimaid-70b",
       "name": "NeverSleep: Llama 3 Lumimaid 70B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000045",
+        "completion": "0.000006",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.000003375",
+        "prompt": "0.000004",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
-        "max_completion_tokens": 2048
+        "max_completion_tokens": 4096
       }
     },
     {
@@ -5899,17 +8818,32 @@
       "context_length": 24576,
       "created": 1714780800,
       "description": "The NeverSleep team is back, with a Llama 3 8B finetune trained on their curated roleplay data. Striking a balance between eRP and RP, Lumimaid was designed to be serious, yet uncensored when necessary.\n\nTo enhance it's overall intelligence and chat capability, roughly 40% of the training data was not roleplay. This provides a breadth of knowledge to access, while still keeping roleplay as the primary strength.\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "NeverSleep/Llama-3-Lumimaid-8B-v0.1",
       "id": "neversleep/llama-3-lumimaid-8b",
       "name": "NeverSleep: Llama 3 Lumimaid 8B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000075",
+        "completion": "0.00000125",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000009375",
+        "prompt": "0.0000002",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed",
+        "logit_bias",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 24576,
         "is_moderated": false,
@@ -5931,17 +8865,32 @@
       "context_length": 24576,
       "created": 1714780800,
       "description": "The NeverSleep team is back, with a Llama 3 8B finetune trained on their curated roleplay data. Striking a balance between eRP and RP, Lumimaid was designed to be serious, yet uncensored when necessary.\n\nTo enhance it's overall intelligence and chat capability, roughly 40% of the training data was not roleplay. This provides a breadth of knowledge to access, while still keeping roleplay as the primary strength.\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "NeverSleep/Llama-3-Lumimaid-8B-v0.1",
       "id": "neversleep/llama-3-lumimaid-8b:extended",
       "name": "NeverSleep: Llama 3 Lumimaid 8B (extended)",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000075",
+        "completion": "0.00000125",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000009375",
+        "prompt": "0.0000002",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 24576,
         "is_moderated": false,
@@ -5963,17 +8912,32 @@
       "context_length": 16384,
       "created": 1729555200,
       "description": "Lumimaid v0.2 70B is a finetune of [Llama 3.1 70B](/meta-llama/llama-3.1-70b-instruct) with a \"HUGE step up dataset wise\" compared to Lumimaid v0.1. Sloppy chats output were purged.\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "NeverSleep/Lumimaid-v0.2-70B",
       "id": "neversleep/llama-3.1-lumimaid-70b",
       "name": "NeverSleep: Lumimaid v0.2 70B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000225",
+        "completion": "0.000003",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000015",
+        "prompt": "0.0000025",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -5995,17 +8959,32 @@
       "context_length": 32768,
       "created": 1726358400,
       "description": "Lumimaid v0.2 8B is a finetune of [Llama 3.1 8B](/models/meta-llama/llama-3.1-8b-instruct) with a \"HUGE step up dataset wise\" compared to Lumimaid v0.1. Sloppy chats output were purged.\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://llama.meta.com/llama3/use-policy/).",
+      "hugging_face_id": "NeverSleep/Lumimaid-v0.2-8B",
       "id": "neversleep/llama-3.1-lumimaid-8b",
       "name": "NeverSleep: Lumimaid v0.2 8B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000075",
+        "completion": "0.00000125",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000009375",
+        "prompt": "0.0000002",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed",
+        "logit_bias",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -6027,17 +9006,32 @@
       "context_length": 8192,
       "created": 1700956800,
       "description": "A collab between IkariDev and Undi. This merge is suitable for RP, ERP, and general knowledge.\n\n#merge #uncensored",
+      "hugging_face_id": "NeverSleep/Noromaid-20b-v0.1.1",
       "id": "neversleep/noromaid-20b",
       "name": "Noromaid 20B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000015",
+        "completion": "0.000002",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000075",
+        "prompt": "0.00000125",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -6059,6 +9053,7 @@
       "context_length": 131072,
       "created": 1740719372,
       "description": "DeepHermes 3 Preview is the latest version of our flagship Hermes series of LLMs by Nous Research, and one of the first models in the world to unify Reasoning (long chains of thought that improve answer accuracy) and normal LLM response modes into one model. We have also improved LLM annotation, judgement, and function calling.\n\nDeepHermes 3 Preview is one of the first LLM models to unify both \"intuitive\", traditional mode responses and long chain of thought reasoning responses into a single model, toggled by a system prompt.",
+      "hugging_face_id": "NousResearch/DeepHermes-3-Llama-3-8B-Preview",
       "id": "nousresearch/deephermes-3-llama-3-8b-preview:free",
       "name": "Nous: DeepHermes 3 Llama 3 8B Preview (free)",
       "per_request_limits": null,
@@ -6070,6 +9065,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -6081,29 +9091,47 @@
         "input_modalities": [
           "text"
         ],
-        "instruct_type": "alpaca",
+        "instruct_type": null,
         "modality": "text->text",
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Llama2"
+        "tokenizer": "Other"
       },
-      "context_length": 4096,
-      "created": 1692489600,
-      "description": "A state-of-the-art language model fine-tuned on over 300k instructions by Nous Research, with Teknium and Emozilla leading the fine tuning process.",
-      "id": "nousresearch/nous-hermes-llama2-13b",
-      "name": "Nous: Hermes 13B",
+      "context_length": 32768,
+      "created": 1746830904,
+      "description": "DeepHermes 3 (Mistral 24B Preview) is an instruction-tuned language model by Nous Research based on Mistral-Small-24B, designed for chat, function calling, and advanced multi-turn reasoning. It introduces a dual-mode system that toggles between intuitive chat responses and structured “deep reasoning” mode using special system prompts. Fine-tuned via distillation from R1, it supports structured output (JSON mode) and function call syntax for agent-based applications.\n\nDeepHermes 3 supports a **reasoning toggle via system prompt**, allowing users to switch between fast, intuitive responses and deliberate, multi-step reasoning. When activated with the following specific system instruction, the model enters a *\"deep thinking\"* mode—generating extended chains of thought wrapped in `<think></think>` tags before delivering a final answer. \n\nSystem Prompt: You are a deep thinking AI, you may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes to help come to a correct solution prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem.\n",
+      "hugging_face_id": "NousResearch/DeepHermes-3-Mistral-24B-Preview",
+      "id": "nousresearch/deephermes-3-mistral-24b-preview:free",
+      "name": "Nous: DeepHermes 3 Mistral 24B Preview (free)",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000018",
+        "completion": "0",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000018",
+        "prompt": "0",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 4096,
+        "context_length": 32768,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -6123,6 +9151,7 @@
       "context_length": 32768,
       "created": 1705363200,
       "description": "Nous Hermes 2 Mixtral 8x7B DPO is the new flagship Nous Research model trained over the [Mixtral 8x7B MoE LLM](/models/mistralai/mixtral-8x7b).\n\nThe model was trained on over 1,000,000 entries of primarily [GPT-4](/models/openai/gpt-4) generated data, as well as other high quality data from open datasets across the AI landscape, achieving state of the art performance on a variety of tasks.\n\n#moe",
+      "hugging_face_id": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
       "id": "nousresearch/nous-hermes-2-mixtral-8x7b-dpo",
       "name": "Nous: Hermes 2 Mixtral 8x7B DPO",
       "per_request_limits": null,
@@ -6134,6 +9163,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -6155,6 +9197,7 @@
       "context_length": 131072,
       "created": 1723766400,
       "description": "Hermes 3 is a generalist language model with many improvements over Hermes 2, including advanced agentic capabilities, much better roleplaying, reasoning, multi-turn conversation, long context coherence, and improvements across the board.\n\nHermes 3 405B is a frontier-level, full-parameter finetune of the Llama-3.1 405B foundation model, focused on aligning LLMs to the user, with powerful steering capabilities and control given to the end user.\n\nThe Hermes 3 series builds and expands on the Hermes 2 set of capabilities, including more powerful and reliable function calling and structured output capabilities, generalist assistant capabilities, and improved code generation skills.\n\nHermes 3 is competitive, if not superior, to Llama-3.1 Instruct models at general capabilities, with varying strengths and weaknesses attributable between the two.",
+      "hugging_face_id": "NousResearch/Hermes-3-Llama-3.1-405B",
       "id": "nousresearch/hermes-3-llama-3.1-405b",
       "name": "Nous: Hermes 3 405B Instruct",
       "per_request_limits": null,
@@ -6162,14 +9205,30 @@
         "completion": "0.0000008",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000008",
+        "prompt": "0.0000007",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "top_k",
+        "repetition_penalty",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 131072
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -6187,6 +9246,7 @@
       "context_length": 131072,
       "created": 1723939200,
       "description": "Hermes 3 is a generalist language model with many improvements over [Hermes 2](/models/nousresearch/nous-hermes-2-mistral-7b-dpo), including advanced agentic capabilities, much better roleplaying, reasoning, multi-turn conversation, long context coherence, and improvements across the board.\n\nHermes 3 70B is a competitive, if not superior finetune of the [Llama-3.1 70B foundation model](/models/meta-llama/llama-3.1-70b-instruct), focused on aligning LLMs to the user, with powerful steering capabilities and control given to the end user.\n\nThe Hermes 3 series builds and expands on the Hermes 2 set of capabilities, including more powerful and reliable function calling and structured output capabilities, generalist assistant capabilities, and improved code generation skills.",
+      "hugging_face_id": "NousResearch/Hermes-3-Llama-3.1-70B",
       "id": "nousresearch/hermes-3-llama-3.1-70b",
       "name": "Nous: Hermes 3 70B Instruct",
       "per_request_limits": null,
@@ -6198,6 +9258,24 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "tools",
+        "tool_choice"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -6219,6 +9297,7 @@
       "context_length": 131072,
       "created": 1716768000,
       "description": "Hermes 2 Pro is an upgraded, retrained version of Nous Hermes 2, consisting of an updated and cleaned version of the OpenHermes 2.5 Dataset, as well as a newly introduced Function Calling and JSON Mode dataset developed in-house.",
+      "hugging_face_id": "NousResearch/Hermes-2-Pro-Llama-3-8B",
       "id": "nousresearch/hermes-2-pro-llama-3-8b",
       "name": "NousResearch: Hermes 2 Pro - Llama-3 8B",
       "per_request_limits": null,
@@ -6230,6 +9309,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "top_k",
+        "min_p",
+        "repetition_penalty"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -6251,6 +9346,7 @@
       "context_length": 131072,
       "created": 1728950400,
       "description": "NVIDIA's Llama 3.1 Nemotron 70B is a language model designed for generating precise and useful responses. Leveraging [Llama 3.1 70B](/models/meta-llama/llama-3.1-70b-instruct) architecture and Reinforcement Learning from Human Feedback (RLHF), it excels in automatic alignment benchmarks. This model is tailored for applications requiring high accuracy in helpfulness and response generation, suitable for diverse user queries across multiple domains.\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
+      "hugging_face_id": "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
       "id": "nvidia/llama-3.1-nemotron-70b-instruct",
       "name": "NVIDIA: Llama 3.1 Nemotron 70B Instruct",
       "per_request_limits": null,
@@ -6262,74 +9358,28 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "top_k",
+        "repetition_penalty",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
         "max_completion_tokens": 131072
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "llama3",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3"
-      },
-      "context_length": 131072,
-      "created": 1728950400,
-      "description": "NVIDIA's Llama 3.1 Nemotron 70B is a language model designed for generating precise and useful responses. Leveraging [Llama 3.1 70B](/models/meta-llama/llama-3.1-70b-instruct) architecture and Reinforcement Learning from Human Feedback (RLHF), it excels in automatic alignment benchmarks. This model is tailored for applications requiring high accuracy in helpfulness and response generation, suitable for diverse user queries across multiple domains.\n\nUsage of this model is subject to [Meta's Acceptable Use Policy](https://www.llama.com/llama3/use-policy/).",
-      "id": "nvidia/llama-3.1-nemotron-70b-instruct:free",
-      "name": "NVIDIA: Llama 3.1 Nemotron 70B Instruct (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 131072,
-      "created": 1744123873,
-      "description": "Llama-3.1-Nemotron-Nano-8B-v1 is a compact large language model (LLM) derived from Meta's Llama-3.1-8B-Instruct, specifically optimized for reasoning tasks, conversational interactions, retrieval-augmented generation (RAG), and tool-calling applications. It balances accuracy and efficiency, fitting comfortably onto a single consumer-grade RTX GPU for local deployment. The model supports extended context lengths of up to 128K tokens.\n\nNote: you must include `detailed thinking on` in the system prompt to enable reasoning. Please see [Usage Recommendations](https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1#quick-start-and-usage-recommendations) for more.",
-      "id": "nvidia/llama-3.1-nemotron-nano-8b-v1:free",
-      "name": "NVIDIA: Llama 3.1 Nemotron Nano 8B v1 (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "is_moderated": false,
-        "max_completion_tokens": null
       }
     },
     {
@@ -6347,6 +9397,7 @@
       "context_length": 131072,
       "created": 1744115059,
       "description": "Llama-3.1-Nemotron-Ultra-253B-v1 is a large language model (LLM) optimized for advanced reasoning, human-interactive chat, retrieval-augmented generation (RAG), and tool-calling tasks. Derived from Meta’s Llama-3.1-405B-Instruct, it has been significantly customized using Neural Architecture Search (NAS), resulting in enhanced efficiency, reduced memory usage, and improved inference latency. The model supports a context length of up to 128K tokens and can operate efficiently on an 8x NVIDIA H100 node.\n\nNote: you must include `detailed thinking on` in the system prompt to enable reasoning. Please see [Usage Recommendations](https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1#quick-start-and-usage-recommendations) for more.",
+      "hugging_face_id": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
       "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1:free",
       "name": "NVIDIA: Llama 3.1 Nemotron Ultra 253B v1 (free)",
       "per_request_limits": null,
@@ -6358,6 +9409,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -6379,6 +9445,53 @@
       "context_length": 131072,
       "created": 1744119494,
       "description": "Llama-3.3-Nemotron-Super-49B-v1 is a large language model (LLM) optimized for advanced reasoning, conversational interactions, retrieval-augmented generation (RAG), and tool-calling tasks. Derived from Meta's Llama-3.3-70B-Instruct, it employs a Neural Architecture Search (NAS) approach, significantly enhancing efficiency and reducing memory requirements. This allows the model to support a context length of up to 128K tokens and fit efficiently on single high-performance GPUs, such as NVIDIA H200.\n\nNote: you must include `detailed thinking on` in the system prompt to enable reasoning. Please see [Usage Recommendations](https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1#quick-start-and-usage-recommendations) for more.",
+      "hugging_face_id": "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
+      "id": "nvidia/llama-3.3-nemotron-super-49b-v1",
+      "name": "NVIDIA: Llama 3.3 Nemotron Super 49B v1",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000004",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000013",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 131072,
+      "created": 1744119494,
+      "description": "Llama-3.3-Nemotron-Super-49B-v1 is a large language model (LLM) optimized for advanced reasoning, conversational interactions, retrieval-augmented generation (RAG), and tool-calling tasks. Derived from Meta's Llama-3.3-70B-Instruct, it employs a Neural Architecture Search (NAS) approach, significantly enhancing efficiency and reducing memory requirements. This allows the model to support a context length of up to 128K tokens and fit efficiently on single high-performance GPUs, such as NVIDIA H200.\n\nNote: you must include `detailed thinking on` in the system prompt to enable reasoning. Please see [Usage Recommendations](https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1#quick-start-and-usage-recommendations) for more.",
+      "hugging_face_id": "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
       "id": "nvidia/llama-3.3-nemotron-super-49b-v1:free",
       "name": "NVIDIA: Llama 3.3 Nemotron Super 49B v1 (free)",
       "per_request_limits": null,
@@ -6390,8 +9503,69 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "zephyr",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 2048,
+      "created": 1715299200,
+      "description": "OLMo 7B Instruct by the Allen Institute for AI is a model finetuned for question answering. It demonstrates **notable performance** across multiple benchmarks including TruthfulQA and ToxiGen.\n\n**Open Source**: The model, its code, checkpoints, logs are released under the [Apache 2.0 license](https://choosealicense.com/licenses/apache-2.0).\n\n- [Core repo (training, inference, fine-tuning etc.)](https://github.com/allenai/OLMo)\n- [Evaluation code](https://github.com/allenai/OLMo-Eval)\n- [Further fine-tuning code](https://github.com/allenai/open-instruct)\n- [Paper](https://arxiv.org/abs/2402.00838)\n- [Technical blog post](https://blog.allenai.org/olmo-open-language-model-87ccfc95f580)\n- [W&B Logs](https://wandb.ai/ai2-llm/OLMo-7B/reports/OLMo-7B--Vmlldzo2NzQyMzk5)",
+      "hugging_face_id": "allenai/OLMo-7B-Instruct",
+      "id": "allenai/olmo-7b-instruct",
+      "name": "OLMo 7B Instruct",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000024",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000008",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 2048,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -6411,6 +9585,7 @@
       "context_length": 32768,
       "created": 1742077228,
       "description": "OlympicCoder-32B is a high-performing open-source model fine-tuned using the CodeForces-CoTs dataset, containing approximately 100,000 chain-of-thought programming samples. It excels at complex competitive programming benchmarks, such as IOI 2024 and Codeforces-style challenges, frequently surpassing state-of-the-art closed-source models. OlympicCoder-32B provides advanced reasoning, coherent multi-step problem-solving, and robust code generation capabilities, demonstrating significant potential for olympiad-level competitive programming applications.",
+      "hugging_face_id": "open-r1/OlympicCoder-32B",
       "id": "open-r1/olympiccoder-32b:free",
       "name": "OlympicCoder 32B (free)",
       "per_request_limits": null,
@@ -6422,38 +9597,23 @@
         "request": "0",
         "web_search": "0"
       },
-      "top_provider": {
-        "context_length": 32768,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "deepseek-r1",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 32768,
-      "created": 1742078265,
-      "description": "OlympicCoder-7B is an open-source language model fine-tuned on the CodeForces-CoTs dataset, consisting of nearly 100,000 high-quality chain-of-thought examples from competitive programming contexts. Optimized specifically for olympiad-level coding problems, this model demonstrates strong chain-of-thought reasoning and competitive code generation capabilities, achieving performance competitive with frontier closed-source models on tasks from the IOI 2024 and similar coding contests.",
-      "id": "open-r1/olympiccoder-7b:free",
-      "name": "OlympicCoder 7B (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -6476,6 +9636,7 @@
       "context_length": 128000,
       "created": 1723593600,
       "description": "OpenAI ChatGPT 4o is continually updated by OpenAI to point to the current version of GPT-4o used by ChatGPT. It therefore differs slightly from the API version of [GPT-4o](/models/openai/gpt-4o) in that it has additional RLHF. It is intended for research and evaluation.\n\nOpenAI notes that this model is not suited for production use-cases as it may be removed or redirected to another model in the future.",
+      "hugging_face_id": null,
       "id": "openai/chatgpt-4o-latest",
       "name": "OpenAI: ChatGPT-4o",
       "per_request_limits": null,
@@ -6487,10 +9648,75 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
         "max_completion_tokens": 16384
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT"
+      },
+      "context_length": 200000,
+      "created": 1747409761,
+      "description": "codex-mini-latest is a fine-tuned version of o4-mini specifically for use in Codex CLI. For direct use in the API, we recommend starting with gpt-4.1.",
+      "hugging_face_id": "",
+      "id": "openai/codex-mini",
+      "name": "OpenAI: Codex Mini",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.000006",
+        "image": "0",
+        "input_cache_read": "0.000000375",
+        "internal_reasoning": "0",
+        "prompt": "0.0000015",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "reasoning",
+        "include_reasoning",
+        "structured_outputs",
+        "response_format",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 200000,
+        "is_moderated": true,
+        "max_completion_tokens": 100000
       }
     },
     {
@@ -6508,6 +9734,7 @@
       "context_length": 16385,
       "created": 1685232000,
       "description": "GPT-3.5 Turbo is OpenAI's fastest model. It can understand and generate natural language or code, and is optimized for chat and traditional completion tasks.\n\nTraining data up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-3.5-turbo",
       "name": "OpenAI: GPT-3.5 Turbo",
       "per_request_limits": null,
@@ -6519,6 +9746,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 16385,
         "is_moderated": true,
@@ -6540,6 +9782,7 @@
       "context_length": 4095,
       "created": 1706140800,
       "description": "GPT-3.5 Turbo is OpenAI's fastest model. It can understand and generate natural language or code, and is optimized for chat and traditional completion tasks.\n\nTraining data up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-3.5-turbo-0613",
       "name": "OpenAI: GPT-3.5 Turbo (older v0613)",
       "per_request_limits": null,
@@ -6551,6 +9794,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 4095,
         "is_moderated": false,
@@ -6572,6 +9831,7 @@
       "context_length": 16385,
       "created": 1693180800,
       "description": "This model offers four times the context length of gpt-3.5-turbo, allowing it to support approximately 20 pages of text in a single request at a higher cost. Training data: up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-3.5-turbo-16k",
       "name": "OpenAI: GPT-3.5 Turbo 16k",
       "per_request_limits": null,
@@ -6583,6 +9843,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 16385,
         "is_moderated": true,
@@ -6604,6 +9879,7 @@
       "context_length": 16385,
       "created": 1685232000,
       "description": "The latest GPT-3.5 Turbo model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. Training data: up to Sep 2021.\n\nThis version has a higher accuracy at responding in requested formats and a fix for a bug which caused a text encoding issue for non-English language function calls.",
+      "hugging_face_id": null,
       "id": "openai/gpt-3.5-turbo-0125",
       "name": "OpenAI: GPT-3.5 Turbo 16k",
       "per_request_limits": null,
@@ -6615,6 +9891,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 16385,
         "is_moderated": true,
@@ -6636,6 +9927,7 @@
       "context_length": 16385,
       "created": 1699228800,
       "description": "An older GPT-3.5 Turbo model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. Training data: up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-3.5-turbo-1106",
       "name": "OpenAI: GPT-3.5 Turbo 16k (older v1106)",
       "per_request_limits": null,
@@ -6647,6 +9939,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 16385,
         "is_moderated": true,
@@ -6668,6 +9976,7 @@
       "context_length": 4095,
       "created": 1695859200,
       "description": "This model is a variant of GPT-3.5 Turbo tuned for instructional prompts and omitting chat-related optimizations. Training data: up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-3.5-turbo-instruct",
       "name": "OpenAI: GPT-3.5 Turbo Instruct",
       "per_request_limits": null,
@@ -6679,6 +9988,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 4095,
         "is_moderated": true,
@@ -6700,6 +10022,7 @@
       "context_length": 8191,
       "created": 1685232000,
       "description": "OpenAI's flagship model, GPT-4 is a large-scale multimodal language model capable of solving difficult problems with greater accuracy than previous models due to its broader general knowledge and advanced reasoning capabilities. Training data: up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-4",
       "name": "OpenAI: GPT-4",
       "per_request_limits": null,
@@ -6711,6 +10034,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 8191,
         "is_moderated": true,
@@ -6732,6 +10070,7 @@
       "context_length": 8191,
       "created": 1685232000,
       "description": "GPT-4-0314 is the first version of GPT-4 released, with a context length of 8,192 tokens, and was supported until June 14. Training data: up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-4-0314",
       "name": "OpenAI: GPT-4 (older v0314)",
       "per_request_limits": null,
@@ -6743,6 +10082,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 8191,
         "is_moderated": true,
@@ -6764,6 +10119,7 @@
       "context_length": 32767,
       "created": 1693180800,
       "description": "GPT-4-32k is an extended version of GPT-4, with the same capabilities but quadrupled context length, allowing for processing up to 40 pages of text in a single pass. This is particularly beneficial for handling longer content like interacting with PDFs without an external vector database. Training data: up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-4-32k",
       "name": "OpenAI: GPT-4 32k",
       "per_request_limits": null,
@@ -6775,6 +10131,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 32767,
         "is_moderated": true,
@@ -6796,6 +10167,7 @@
       "context_length": 32767,
       "created": 1693180800,
       "description": "GPT-4-32k is an extended version of GPT-4, with the same capabilities but quadrupled context length, allowing for processing up to 40 pages of text in a single pass. This is particularly beneficial for handling longer content like interacting with PDFs without an external vector database. Training data: up to Sep 2021.",
+      "hugging_face_id": null,
       "id": "openai/gpt-4-32k-0314",
       "name": "OpenAI: GPT-4 32k (older v0314)",
       "per_request_limits": null,
@@ -6807,6 +10179,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 32767,
         "is_moderated": true,
@@ -6829,6 +10217,7 @@
       "context_length": 128000,
       "created": 1712620800,
       "description": "The latest GPT-4 Turbo model with vision capabilities. Vision requests can now use JSON mode and function calling.\n\nTraining data: up to December 2023.",
+      "hugging_face_id": null,
       "id": "openai/gpt-4-turbo",
       "name": "OpenAI: GPT-4 Turbo",
       "per_request_limits": null,
@@ -6840,6 +10229,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -6861,6 +10265,7 @@
       "context_length": 128000,
       "created": 1699228800,
       "description": "The latest GPT-4 Turbo model with vision capabilities. Vision requests can now use JSON mode and function calling.\n\nTraining data: up to April 2023.",
+      "hugging_face_id": null,
       "id": "openai/gpt-4-1106-preview",
       "name": "OpenAI: GPT-4 Turbo (older v1106)",
       "per_request_limits": null,
@@ -6872,6 +10277,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -6893,6 +10314,7 @@
       "context_length": 128000,
       "created": 1706140800,
       "description": "The preview GPT-4 model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. Training data: up to Dec 2023.\n\n**Note:** heavily rate limited by OpenAI while in preview.",
+      "hugging_face_id": null,
       "id": "openai/gpt-4-turbo-preview",
       "name": "OpenAI: GPT-4 Turbo Preview",
       "per_request_limits": null,
@@ -6904,6 +10326,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -6914,7 +10352,8 @@
       "architecture": {
         "input_modalities": [
           "image",
-          "text"
+          "text",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -6926,6 +10365,7 @@
       "context_length": 1047576,
       "created": 1744651385,
       "description": "GPT-4.1 is a flagship large language model optimized for advanced instruction following, real-world software engineering, and long-context reasoning. It supports a 1 million token context window and outperforms GPT-4o and GPT-4.5 across coding (54.6% SWE-bench Verified), instruction compliance (87.4% IFEval), and multimodal understanding benchmarks. It is tuned for precise code diffs, agent reliability, and high recall in large document contexts, making it ideal for agents, IDE tooling, and enterprise knowledge retrieval.",
+      "hugging_face_id": "",
       "id": "openai/gpt-4.1",
       "name": "OpenAI: GPT-4.1",
       "per_request_limits": null,
@@ -6938,6 +10378,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 1047576,
         "is_moderated": true,
@@ -6948,7 +10405,8 @@
       "architecture": {
         "input_modalities": [
           "image",
-          "text"
+          "text",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -6960,6 +10418,7 @@
       "context_length": 1047576,
       "created": 1744651381,
       "description": "GPT-4.1 Mini is a mid-sized model delivering performance competitive with GPT-4o at substantially lower latency and cost. It retains a 1 million token context window and scores 45.1% on hard instruction evals, 35.8% on MultiChallenge, and 84.1% on IFEval. Mini also shows strong coding ability (e.g., 31.6% on Aider’s polyglot diff benchmark) and vision understanding, making it suitable for interactive applications with tight performance constraints.",
+      "hugging_face_id": "",
       "id": "openai/gpt-4.1-mini",
       "name": "OpenAI: GPT-4.1 Mini",
       "per_request_limits": null,
@@ -6972,6 +10431,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 1047576,
         "is_moderated": true,
@@ -6982,7 +10458,8 @@
       "architecture": {
         "input_modalities": [
           "image",
-          "text"
+          "text",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -6994,6 +10471,7 @@
       "context_length": 1047576,
       "created": 1744651369,
       "description": "For tasks that demand low latency, GPT‑4.1 nano is the fastest and cheapest model in the GPT-4.1 series. It delivers exceptional performance at a small size with its 1 million token context window, and scores 80.1% on MMLU, 50.3% on GPQA, and 9.8% on Aider polyglot coding – even higher than GPT‑4o mini. It’s ideal for tasks like classification or autocompletion.",
+      "hugging_face_id": "",
       "id": "openai/gpt-4.1-nano",
       "name": "OpenAI: GPT-4.1 Nano",
       "per_request_limits": null,
@@ -7006,6 +10484,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 1047576,
         "is_moderated": true,
@@ -7028,6 +10522,7 @@
       "context_length": 128000,
       "created": 1740687810,
       "description": "GPT-4.5 (Preview) is a research preview of OpenAI’s latest language model, designed to advance capabilities in reasoning, creativity, and multi-turn conversation. It builds on previous iterations with improvements in world knowledge, contextual coherence, and the ability to follow user intent more effectively.\n\nThe model demonstrates enhanced performance in tasks that require open-ended thinking, problem-solving, and communication. Early testing suggests it is better at generating nuanced responses, maintaining long-context coherence, and reducing hallucinations compared to earlier versions.\n\nThis research preview is intended to help evaluate GPT-4.5’s strengths and limitations in real-world use cases as OpenAI continues to refine and develop future models. Read more at the [blog post here.](https://openai.com/index/introducing-gpt-4-5/)",
+      "hugging_face_id": "",
       "id": "openai/gpt-4.5-preview",
       "name": "OpenAI: GPT-4.5 (Preview)",
       "per_request_limits": null,
@@ -7040,6 +10535,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7050,7 +10561,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7062,6 +10574,7 @@
       "context_length": 128000,
       "created": 1715558400,
       "description": "GPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs. It maintains the intelligence level of [GPT-4 Turbo](/models/openai/gpt-4-turbo) while being twice as fast and 50% more cost-effective. GPT-4o also offers improved performance in processing non-English languages and enhanced visual capabilities.\n\nFor benchmarking against other models, it was briefly called [\"im-also-a-good-gpt2-chatbot\"](https://twitter.com/LiamFedus/status/1790064963966370209)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "openai/gpt-4o",
       "name": "OpenAI: GPT-4o",
       "per_request_limits": null,
@@ -7074,6 +10587,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7084,7 +10614,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7096,6 +10627,7 @@
       "context_length": 128000,
       "created": 1715558400,
       "description": "GPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs. It maintains the intelligence level of [GPT-4 Turbo](/models/openai/gpt-4-turbo) while being twice as fast and 50% more cost-effective. GPT-4o also offers improved performance in processing non-English languages and enhanced visual capabilities.\n\nFor benchmarking against other models, it was briefly called [\"im-also-a-good-gpt2-chatbot\"](https://twitter.com/LiamFedus/status/1790064963966370209)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "openai/gpt-4o-2024-05-13",
       "name": "OpenAI: GPT-4o (2024-05-13)",
       "per_request_limits": null,
@@ -7107,6 +10639,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7117,7 +10666,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7129,6 +10679,7 @@
       "context_length": 128000,
       "created": 1722902400,
       "description": "The 2024-08-06 version of GPT-4o offers improved performance in structured outputs, with the ability to supply a JSON schema in the respone_format. Read more [here](https://openai.com/index/introducing-structured-outputs-in-the-api/).\n\nGPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs. It maintains the intelligence level of [GPT-4 Turbo](/models/openai/gpt-4-turbo) while being twice as fast and 50% more cost-effective. GPT-4o also offers improved performance in processing non-English languages and enhanced visual capabilities.\n\nFor benchmarking against other models, it was briefly called [\"im-also-a-good-gpt2-chatbot\"](https://twitter.com/LiamFedus/status/1790064963966370209)",
+      "hugging_face_id": null,
       "id": "openai/gpt-4o-2024-08-06",
       "name": "OpenAI: GPT-4o (2024-08-06)",
       "per_request_limits": null,
@@ -7141,6 +10692,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7151,7 +10719,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7163,6 +10732,7 @@
       "context_length": 128000,
       "created": 1732127594,
       "description": "The 2024-11-20 version of GPT-4o offers a leveled-up creative writing ability with more natural, engaging, and tailored writing to improve relevance & readability. It’s also better at working with uploaded files, providing deeper insights & more thorough responses.\n\nGPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs. It maintains the intelligence level of [GPT-4 Turbo](/models/openai/gpt-4-turbo) while being twice as fast and 50% more cost-effective. GPT-4o also offers improved performance in processing non-English languages and enhanced visual capabilities.",
+      "hugging_face_id": "",
       "id": "openai/gpt-4o-2024-11-20",
       "name": "OpenAI: GPT-4o (2024-11-20)",
       "per_request_limits": null,
@@ -7175,6 +10745,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7185,7 +10772,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7197,6 +10785,7 @@
       "context_length": 128000,
       "created": 1715558400,
       "description": "GPT-4o (\"o\" for \"omni\") is OpenAI's latest AI model, supporting both text and image inputs with text outputs. It maintains the intelligence level of [GPT-4 Turbo](/models/openai/gpt-4-turbo) while being twice as fast and 50% more cost-effective. GPT-4o also offers improved performance in processing non-English languages and enhanced visual capabilities.\n\nFor benchmarking against other models, it was briefly called [\"im-also-a-good-gpt2-chatbot\"](https://twitter.com/LiamFedus/status/1790064963966370209)\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "openai/gpt-4o:extended",
       "name": "OpenAI: GPT-4o (extended)",
       "per_request_limits": null,
@@ -7208,6 +10797,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7217,11 +10823,10 @@
     {
       "architecture": {
         "input_modalities": [
-          "text",
-          "image"
+          "text"
         ],
         "instruct_type": null,
-        "modality": "text+image->text",
+        "modality": "text->text",
         "output_modalities": [
           "text"
         ],
@@ -7230,6 +10835,7 @@
       "context_length": 128000,
       "created": 1741817949,
       "description": "GPT-4o Search Previewis a specialized model for web search in Chat Completions. It is trained to understand and execute web search queries.",
+      "hugging_face_id": "",
       "id": "openai/gpt-4o-search-preview",
       "name": "OpenAI: GPT-4o Search Preview",
       "per_request_limits": null,
@@ -7241,6 +10847,12 @@
         "request": "0.035",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "web_search_options",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7251,7 +10863,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7263,6 +10876,7 @@
       "context_length": 128000,
       "created": 1721260800,
       "description": "GPT-4o mini is OpenAI's newest model after [GPT-4 Omni](/models/openai/gpt-4o), supporting both text and image inputs with text outputs.\n\nAs their most advanced small model, it is many multiples more affordable than other recent frontier models, and more than 60% cheaper than [GPT-3.5 Turbo](/models/openai/gpt-3.5-turbo). It maintains SOTA intelligence, while being significantly more cost-effective.\n\nGPT-4o mini achieves an 82% score on MMLU and presently ranks higher than GPT-4 on chat preferences [common leaderboards](https://arena.lmsys.org/).\n\nCheck out the [launch announcement](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/) to learn more.\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "openai/gpt-4o-mini",
       "name": "OpenAI: GPT-4o-mini",
       "per_request_limits": null,
@@ -7275,6 +10889,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs",
+        "tools",
+        "tool_choice"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7285,7 +10916,8 @@
       "architecture": {
         "input_modalities": [
           "text",
-          "image"
+          "image",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7297,6 +10929,7 @@
       "context_length": 128000,
       "created": 1721260800,
       "description": "GPT-4o mini is OpenAI's newest model after [GPT-4 Omni](/models/openai/gpt-4o), supporting both text and image inputs with text outputs.\n\nAs their most advanced small model, it is many multiples more affordable than other recent frontier models, and more than 60% cheaper than [GPT-3.5 Turbo](/models/openai/gpt-3.5-turbo). It maintains SOTA intelligence, while being significantly more cost-effective.\n\nGPT-4o mini achieves an 82% score on MMLU and presently ranks higher than GPT-4 on chat preferences [common leaderboards](https://arena.lmsys.org/).\n\nCheck out the [launch announcement](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/) to learn more.\n\n#multimodal",
+      "hugging_face_id": null,
       "id": "openai/gpt-4o-mini-2024-07-18",
       "name": "OpenAI: GPT-4o-mini (2024-07-18)",
       "per_request_limits": null,
@@ -7309,6 +10942,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "web_search_options",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7318,11 +10968,10 @@
     {
       "architecture": {
         "input_modalities": [
-          "text",
-          "image"
+          "text"
         ],
         "instruct_type": null,
-        "modality": "text+image->text",
+        "modality": "text->text",
         "output_modalities": [
           "text"
         ],
@@ -7331,6 +10980,7 @@
       "context_length": 128000,
       "created": 1741818122,
       "description": "GPT-4o mini Search Preview is a specialized model for web search in Chat Completions. It is trained to understand and execute web search queries.",
+      "hugging_face_id": "",
       "id": "openai/gpt-4o-mini-search-preview",
       "name": "OpenAI: GPT-4o-mini Search Preview",
       "per_request_limits": null,
@@ -7342,6 +10992,12 @@
         "request": "0.0275",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "web_search_options",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7364,6 +11020,7 @@
       "context_length": 200000,
       "created": 1734459999,
       "description": "The latest and strongest model family from OpenAI, o1 is designed to spend more time thinking before responding. The o1 model series is trained with large-scale reinforcement learning to reason using chain of thought. \n\nThe o1 models are optimized for math, science, programming, and other STEM-related tasks. They consistently exhibit PhD-level accuracy on benchmarks in physics, chemistry, and biology. Learn more in the [launch announcement](https://openai.com/o1).\n",
+      "hugging_face_id": "",
       "id": "openai/o1",
       "name": "OpenAI: o1",
       "per_request_limits": null,
@@ -7376,6 +11033,14 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "seed",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -7397,6 +11062,7 @@
       "context_length": 128000,
       "created": 1726099200,
       "description": "The latest and strongest model family from OpenAI, o1 is designed to spend more time thinking before responding.\n\nThe o1 models are optimized for math, science, programming, and other STEM-related tasks. They consistently exhibit PhD-level accuracy on benchmarks in physics, chemistry, and biology. Learn more in the [launch announcement](https://openai.com/o1).\n\nNote: This model is currently experimental and not suitable for production use-cases, and may be heavily rate-limited.",
+      "hugging_face_id": null,
       "id": "openai/o1-mini",
       "name": "OpenAI: o1-mini",
       "per_request_limits": null,
@@ -7409,6 +11075,10 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "seed",
+        "max_tokens"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7430,6 +11100,7 @@
       "context_length": 128000,
       "created": 1726099200,
       "description": "The latest and strongest model family from OpenAI, o1 is designed to spend more time thinking before responding.\n\nThe o1 models are optimized for math, science, programming, and other STEM-related tasks. They consistently exhibit PhD-level accuracy on benchmarks in physics, chemistry, and biology. Learn more in the [launch announcement](https://openai.com/o1).\n\nNote: This model is currently experimental and not suitable for production use-cases, and may be heavily rate-limited.",
+      "hugging_face_id": null,
       "id": "openai/o1-mini-2024-09-12",
       "name": "OpenAI: o1-mini (2024-09-12)",
       "per_request_limits": null,
@@ -7442,6 +11113,10 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "seed",
+        "max_tokens"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7463,6 +11138,7 @@
       "context_length": 128000,
       "created": 1726099200,
       "description": "The latest and strongest model family from OpenAI, o1 is designed to spend more time thinking before responding.\n\nThe o1 models are optimized for math, science, programming, and other STEM-related tasks. They consistently exhibit PhD-level accuracy on benchmarks in physics, chemistry, and biology. Learn more in the [launch announcement](https://openai.com/o1).\n\nNote: This model is currently experimental and not suitable for production use-cases, and may be heavily rate-limited.",
+      "hugging_face_id": null,
       "id": "openai/o1-preview",
       "name": "OpenAI: o1-preview",
       "per_request_limits": null,
@@ -7475,6 +11151,10 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "seed",
+        "max_tokens"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7496,6 +11176,7 @@
       "context_length": 128000,
       "created": 1726099200,
       "description": "The latest and strongest model family from OpenAI, o1 is designed to spend more time thinking before responding.\n\nThe o1 models are optimized for math, science, programming, and other STEM-related tasks. They consistently exhibit PhD-level accuracy on benchmarks in physics, chemistry, and biology. Learn more in the [launch announcement](https://openai.com/o1).\n\nNote: This model is currently experimental and not suitable for production use-cases, and may be heavily rate-limited.",
+      "hugging_face_id": null,
       "id": "openai/o1-preview-2024-09-12",
       "name": "OpenAI: o1-preview (2024-09-12)",
       "per_request_limits": null,
@@ -7508,6 +11189,10 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "seed",
+        "max_tokens"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": true,
@@ -7530,6 +11215,7 @@
       "context_length": 200000,
       "created": 1742423211,
       "description": "The o1 series of models are trained with reinforcement learning to think before they answer and perform complex reasoning. The o1-pro model uses more compute to think harder and provide consistently better answers.",
+      "hugging_face_id": "",
       "id": "openai/o1-pro",
       "name": "OpenAI: o1-pro",
       "per_request_limits": null,
@@ -7541,6 +11227,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -7551,7 +11252,8 @@
       "architecture": {
         "input_modalities": [
           "image",
-          "text"
+          "text",
+          "file"
         ],
         "instruct_type": null,
         "modality": "text+image->text",
@@ -7563,6 +11265,7 @@
       "context_length": 200000,
       "created": 1744823457,
       "description": "o3 is a well-rounded and powerful model across domains. It sets a new standard for math, science, coding, and visual reasoning tasks. It also excels at technical writing and instruction-following. Use it to think through multi-step problems that involve analysis across text, code, and images. Note that BYOK is required for this model. Set up here: https://openrouter.ai/settings/integrations",
+      "hugging_face_id": "",
       "id": "openai/o3",
       "name": "OpenAI: o3",
       "per_request_limits": null,
@@ -7575,6 +11278,14 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "seed",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -7596,6 +11307,7 @@
       "context_length": 200000,
       "created": 1738351721,
       "description": "OpenAI o3-mini is a cost-efficient language model optimized for STEM reasoning tasks, particularly excelling in science, mathematics, and coding.\n\nThis model supports the `reasoning_effort` parameter, which can be set to \"high\", \"medium\", or \"low\" to control the thinking time of the model. The default is \"medium\". OpenRouter also offers the model slug `openai/o3-mini-high` to default the parameter to \"high\".\n\nThe model features three adjustable reasoning effort levels and supports key developer capabilities including function calling, structured outputs, and streaming, though it does not include vision processing capabilities.\n\nThe model demonstrates significant improvements over its predecessor, with expert testers preferring its responses 56% of the time and noting a 39% reduction in major errors on complex questions. With medium reasoning effort settings, o3-mini matches the performance of the larger o1 model on challenging reasoning evaluations like AIME and GPQA, while maintaining lower latency and cost.",
+      "hugging_face_id": "",
       "id": "openai/o3-mini",
       "name": "OpenAI: o3 Mini",
       "per_request_limits": null,
@@ -7608,6 +11320,14 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "seed",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -7629,6 +11349,7 @@
       "context_length": 200000,
       "created": 1739372611,
       "description": "OpenAI o3-mini-high is the same model as [o3-mini](/openai/o3-mini) with reasoning_effort set to high. \n\no3-mini is a cost-efficient language model optimized for STEM reasoning tasks, particularly excelling in science, mathematics, and coding. The model features three adjustable reasoning effort levels and supports key developer capabilities including function calling, structured outputs, and streaming, though it does not include vision processing capabilities.\n\nThe model demonstrates significant improvements over its predecessor, with expert testers preferring its responses 56% of the time and noting a 39% reduction in major errors on complex questions. With medium reasoning effort settings, o3-mini matches the performance of the larger o1 model on challenging reasoning evaluations like AIME and GPQA, while maintaining lower latency and cost.",
+      "hugging_face_id": "",
       "id": "openai/o3-mini-high",
       "name": "OpenAI: o3 Mini High",
       "per_request_limits": null,
@@ -7641,6 +11362,14 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "seed",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -7663,6 +11392,7 @@
       "context_length": 200000,
       "created": 1744820942,
       "description": "OpenAI o4-mini is a compact reasoning model in the o-series, optimized for fast, cost-efficient performance while retaining strong multimodal and agentic capabilities. It supports tool use and demonstrates competitive reasoning and coding performance across benchmarks like AIME (99.5% with Python) and SWE-bench, outperforming its predecessor o3-mini and even approaching o3 in some domains.\n\nDespite its smaller size, o4-mini exhibits high accuracy in STEM tasks, visual problem solving (e.g., MathVista, MMMU), and code editing. It is especially well-suited for high-throughput scenarios where latency or cost is critical. Thanks to its efficient architecture and refined reinforcement learning training, o4-mini can chain tools, generate structured outputs, and solve multi-step tasks with minimal delay—often in under a minute.",
+      "hugging_face_id": "",
       "id": "openai/o4-mini",
       "name": "OpenAI: o4 Mini",
       "per_request_limits": null,
@@ -7675,6 +11405,58 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "seed",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
+      "top_provider": {
+        "context_length": 200000,
+        "is_moderated": true,
+        "max_completion_tokens": 100000
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "image",
+          "text",
+          "file"
+        ],
+        "instruct_type": null,
+        "modality": "text+image->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 200000,
+      "created": 1744824212,
+      "description": "OpenAI o4-mini-high is the same model as [o4-mini](/openai/o4-mini) with reasoning_effort set to high. \n\nOpenAI o4-mini is a compact reasoning model in the o-series, optimized for fast, cost-efficient performance while retaining strong multimodal and agentic capabilities. It supports tool use and demonstrates competitive reasoning and coding performance across benchmarks like AIME (99.5% with Python) and SWE-bench, outperforming its predecessor o3-mini and even approaching o3 in some domains.\n\nDespite its smaller size, o4-mini exhibits high accuracy in STEM tasks, visual problem solving (e.g., MathVista, MMMU), and code editing. It is especially well-suited for high-throughput scenarios where latency or cost is critical. Thanks to its efficient architecture and refined reinforcement learning training, o4-mini can chain tools, generate structured outputs, and solve multi-step tasks with minimal delay—often in under a minute.",
+      "hugging_face_id": "",
+      "id": "openai/o4-mini-high",
+      "name": "OpenAI: o4 Mini High",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000044",
+        "image": "0.0008415",
+        "input_cache_read": "0.000000275",
+        "internal_reasoning": "0",
+        "prompt": "0.0000011",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "seed",
+        "max_tokens",
+        "response_format",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": true,
@@ -7694,55 +11476,67 @@
         ],
         "tokenizer": "Other"
       },
-      "context_length": 200000,
-      "created": 1744824212,
-      "description": "OpenAI o4-mini-high is the same model as [o4-mini](/openai/o4-mini) with reasoning_effort set to high. \n\nOpenAI o4-mini is a compact reasoning model in the o-series, optimized for fast, cost-efficient performance while retaining strong multimodal and agentic capabilities. It supports tool use and demonstrates competitive reasoning and coding performance across benchmarks like AIME (99.5% with Python) and SWE-bench, outperforming its predecessor o3-mini and even approaching o3 in some domains.\n\nDespite its smaller size, o4-mini exhibits high accuracy in STEM tasks, visual problem solving (e.g., MathVista, MMMU), and code editing. It is especially well-suited for high-throughput scenarios where latency or cost is critical. Thanks to its efficient architecture and refined reinforcement learning training, o4-mini can chain tools, generate structured outputs, and solve multi-step tasks with minimal delay—often in under a minute.",
-      "id": "openai/o4-mini-high",
-      "name": "OpenAI: o4 Mini High",
+      "context_length": 32000,
+      "created": 1746021355,
+      "description": "The 14b version of the InternVL3 series. An advanced multimodal large language model (MLLM) series that demonstrates superior overall performance. Compared to InternVL 2.5, InternVL3 exhibits superior multimodal perception and reasoning capabilities, while further extending its multimodal capabilities to encompass tool usage, GUI agents, industrial image analysis, 3D vision perception, and more.",
+      "hugging_face_id": "OpenGVLab/InternVL3-14B",
+      "id": "opengvlab/internvl3-14b:free",
+      "name": "OpenGVLab: InternVL3 14B (free)",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000044",
-        "image": "0.0008415",
-        "input_cache_read": "0.000000275",
+        "completion": "0",
+        "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000011",
+        "prompt": "0",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p"
+      ],
       "top_provider": {
-        "context_length": 200000,
-        "is_moderated": true,
-        "max_completion_tokens": 100000
+        "context_length": 32000,
+        "is_moderated": false,
+        "max_completion_tokens": null
       }
     },
     {
       "architecture": {
         "input_modalities": [
+          "image",
           "text"
         ],
-        "instruct_type": "openchat",
-        "modality": "text->text",
+        "instruct_type": null,
+        "modality": "text+image->text",
         "output_modalities": [
           "text"
         ],
-        "tokenizer": "Mistral"
+        "tokenizer": "Other"
       },
-      "context_length": 8192,
-      "created": 1701129600,
-      "description": "OpenChat 7B is a library of open-source language models, fine-tuned with \"C-RLFT (Conditioned Reinforcement Learning Fine-Tuning)\" - a strategy inspired by offline reinforcement learning. It has been trained on mixed-quality data without preference labels.\n\n- For OpenChat fine-tuned on Mistral 7B, check out [OpenChat 7B](/models/openchat/openchat-7b).\n- For OpenChat fine-tuned on Llama 8B, check out [OpenChat 8B](/models/openchat/openchat-8b).\n\n#open-source",
-      "id": "openchat/openchat-7b",
-      "name": "OpenChat 3.5 7B",
+      "context_length": 32000,
+      "created": 1746019807,
+      "description": "The 2b version of the InternVL3 series, for an even higher inference speed and very reasonable performance. An advanced multimodal large language model (MLLM) series that demonstrates superior overall performance. Compared to InternVL 2.5, InternVL3 exhibits superior multimodal perception and reasoning capabilities, while further extending its multimodal capabilities to encompass tool usage, GUI agents, industrial image analysis, 3D vision perception, and more.",
+      "hugging_face_id": "OpenGVLab/InternVL3-2B",
+      "id": "opengvlab/internvl3-2b:free",
+      "name": "OpenGVLab: InternVL3 2B (free)",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000007",
+        "completion": "0",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000007",
+        "prompt": "0",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p"
+      ],
       "top_provider": {
-        "context_length": 8192,
+        "context_length": 32000,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -7762,6 +11556,7 @@
       "context_length": 16384,
       "created": 1743613013,
       "description": "OpenHands LM v0.1 is a 32B open-source coding model fine-tuned from Qwen2.5-Coder-32B-Instruct using reinforcement learning techniques outlined in SWE-Gym. It is optimized for autonomous software development agents and achieves strong performance on SWE-Bench Verified, with a 37.2% resolve rate. The model supports a 128K token context window, making it well-suited for long-horizon code reasoning and large codebase tasks.\n\nOpenHands LM is designed for local deployment and runs on consumer-grade GPUs such as a single 3090. It enables fully offline agent workflows without dependency on proprietary APIs. This release is intended as a research preview, and future updates aim to improve generalizability, reduce repetition, and offer smaller variants.",
+      "hugging_face_id": "all-hands/openhands-lm-32b-v0.1",
       "id": "all-hands/openhands-lm-32b-v0.1",
       "name": "OpenHands LM 32B V0.1",
       "per_request_limits": null,
@@ -7773,6 +11568,20 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16384,
         "is_moderated": false,
@@ -7794,6 +11603,7 @@
       "context_length": 127072,
       "created": 1722470400,
       "description": "Llama 3.1 Sonar is Perplexity's latest model family. It surpasses their earlier Sonar models in cost-efficiency, speed, and performance.\n\nThis is the online version of the [offline chat model](/models/perplexity/llama-3.1-sonar-large-128k-chat). It is focused on delivering helpful, up-to-date, and factual responses. #online",
+      "hugging_face_id": null,
       "id": "perplexity/llama-3.1-sonar-large-128k-online",
       "name": "Perplexity: Llama 3.1 Sonar 70B Online",
       "per_request_limits": null,
@@ -7805,6 +11615,14 @@
         "request": "0.005",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 127072,
         "is_moderated": false,
@@ -7826,6 +11644,7 @@
       "context_length": 127072,
       "created": 1722470400,
       "description": "Llama 3.1 Sonar is Perplexity's latest model family. It surpasses their earlier Sonar models in cost-efficiency, speed, and performance.\n\nThis is the online version of the [offline chat model](/models/perplexity/llama-3.1-sonar-small-128k-chat). It is focused on delivering helpful, up-to-date, and factual responses. #online",
+      "hugging_face_id": null,
       "id": "perplexity/llama-3.1-sonar-small-128k-online",
       "name": "Perplexity: Llama 3.1 Sonar 8B Online",
       "per_request_limits": null,
@@ -7837,6 +11656,14 @@
         "request": "0.005",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 127072,
         "is_moderated": false,
@@ -7858,6 +11685,7 @@
       "context_length": 128000,
       "created": 1740004929,
       "description": "R1 1776 is a version of DeepSeek-R1 that has been post-trained to remove censorship constraints related to topics restricted by the Chinese government. The model retains its original reasoning capabilities while providing direct responses to a wider range of queries. R1 1776 is an offline chat model that does not use the perplexity search subsystem.\n\nThe model was tested on a multilingual dataset of over 1,000 examples covering sensitive topics to measure its likelihood of refusal or overly filtered responses. [Evaluation Results](https://cdn-uploads.huggingface.co/production/uploads/675c8332d01f593dc90817f5/GiN2VqC5hawUgAGJ6oHla.png) Its performance on math and reasoning benchmarks remains similar to the base R1 model. [Reasoning Performance](https://cdn-uploads.huggingface.co/production/uploads/675c8332d01f593dc90817f5/n4Z9Byqp2S7sKUvCvI40R.png)\n\nRead more on the [Blog Post](https://perplexity.ai/hub/blog/open-sourcing-r1-1776)",
+      "hugging_face_id": "perplexity-ai/r1-1776",
       "id": "perplexity/r1-1776",
       "name": "Perplexity: R1 1776",
       "per_request_limits": null,
@@ -7869,6 +11697,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -7878,10 +11721,11 @@
     {
       "architecture": {
         "input_modalities": [
-          "text"
+          "text",
+          "image"
         ],
         "instruct_type": null,
-        "modality": "text->text",
+        "modality": "text+image->text",
         "output_modalities": [
           "text"
         ],
@@ -7890,6 +11734,7 @@
       "context_length": 127072,
       "created": 1738013808,
       "description": "Sonar is lightweight, affordable, fast, and simple to use — now featuring citations and the ability to customize sources. It is designed for companies seeking to integrate lightweight question-and-answer features optimized for speed.",
+      "hugging_face_id": "",
       "id": "perplexity/sonar",
       "name": "Perplexity: Sonar",
       "per_request_limits": null,
@@ -7901,6 +11746,15 @@
         "request": "0.005",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "web_search_options",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 127072,
         "is_moderated": false,
@@ -7922,6 +11776,7 @@
       "context_length": 128000,
       "created": 1741311246,
       "description": "Sonar Deep Research is a research-focused model designed for multi-step retrieval, synthesis, and reasoning across complex topics. It autonomously searches, reads, and evaluates sources, refining its approach as it gathers information. This enables comprehensive report generation across domains like finance, technology, health, and current events.\n\nNotes on Pricing ([Source](https://docs.perplexity.ai/guides/pricing#detailed-pricing-breakdown-for-sonar-deep-research)) \n- Input tokens comprise of Prompt tokens (user prompt) + Citation tokens (these are processed tokens from running searches)\n- Deep Research runs multiple searches to conduct exhaustive research. Searches are priced at $5/1000 searches. A request that does 30 searches will cost $0.15 in this step.\n- Reasoning is a distinct step in Deep Research since it does extensive automated reasoning through all the material it gathers during its research phase. Reasoning tokens here are a bit different than the CoTs in the answer - these are tokens that we use to reason through the research material prior to generating the outputs via the CoTs. Reasoning tokens are priced at $3/1M tokens",
+      "hugging_face_id": "",
       "id": "perplexity/sonar-deep-research",
       "name": "Perplexity: Sonar Deep Research",
       "per_request_limits": null,
@@ -7933,6 +11788,16 @@
         "request": "0",
         "web_search": "0.005"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -7942,10 +11807,11 @@
     {
       "architecture": {
         "input_modalities": [
-          "text"
+          "text",
+          "image"
         ],
         "instruct_type": null,
-        "modality": "text->text",
+        "modality": "text+image->text",
         "output_modalities": [
           "text"
         ],
@@ -7954,6 +11820,7 @@
       "context_length": 200000,
       "created": 1741312423,
       "description": "Note: Sonar Pro pricing includes Perplexity search pricing. See [details here](https://docs.perplexity.ai/guides/pricing#detailed-pricing-breakdown-for-sonar-reasoning-pro-and-sonar-pro)\n\nFor enterprises seeking more advanced capabilities, the Sonar Pro API can handle in-depth, multi-step queries with added extensibility, like double the number of citations per search as Sonar on average. Plus, with a larger context window, it can handle longer and more nuanced searches and follow-up questions. ",
+      "hugging_face_id": "",
       "id": "perplexity/sonar-pro",
       "name": "Perplexity: Sonar Pro",
       "per_request_limits": null,
@@ -7965,6 +11832,15 @@
         "request": "0",
         "web_search": "0.005"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "web_search_options",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 200000,
         "is_moderated": false,
@@ -7986,6 +11862,7 @@
       "context_length": 127000,
       "created": 1738131107,
       "description": "Sonar Reasoning is a reasoning model provided by Perplexity based on [DeepSeek R1](/deepseek/deepseek-r1).\n\nIt allows developers to utilize long chain of thought with built-in web search. Sonar Reasoning is uncensored and hosted in US datacenters. ",
+      "hugging_face_id": "",
       "id": "perplexity/sonar-reasoning",
       "name": "Perplexity: Sonar Reasoning",
       "per_request_limits": null,
@@ -7997,6 +11874,17 @@
         "request": "0.005",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "web_search_options",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 127000,
         "is_moderated": false,
@@ -8006,10 +11894,11 @@
     {
       "architecture": {
         "input_modalities": [
-          "text"
+          "text",
+          "image"
         ],
         "instruct_type": "deepseek-r1",
-        "modality": "text->text",
+        "modality": "text+image->text",
         "output_modalities": [
           "text"
         ],
@@ -8018,6 +11907,7 @@
       "context_length": 128000,
       "created": 1741313308,
       "description": "Note: Sonar Pro pricing includes Perplexity search pricing. See [details here](https://docs.perplexity.ai/guides/pricing#detailed-pricing-breakdown-for-sonar-reasoning-pro-and-sonar-pro)\n\nSonar Reasoning Pro is a premier reasoning model powered by DeepSeek R1 with Chain of Thought (CoT). Designed for advanced use cases, it supports in-depth, multi-step queries with a larger context window and can surface more citations per search, enabling more comprehensive and extensible responses.",
+      "hugging_face_id": "",
       "id": "perplexity/sonar-reasoning-pro",
       "name": "Perplexity: Sonar Reasoning Pro",
       "per_request_limits": null,
@@ -8029,6 +11919,17 @@
         "request": "0",
         "web_search": "0.005"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "web_search_options",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -8047,24 +11948,39 @@
         ],
         "tokenizer": "Llama2"
       },
-      "context_length": 8192,
+      "context_length": 4096,
       "created": 1693612800,
       "description": "A blend of the new Pygmalion-13b and MythoMax. #merge",
+      "hugging_face_id": "PygmalionAI/mythalion-13b",
       "id": "pygmalionai/mythalion-13b",
       "name": "Pygmalion: Mythalion 13B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000001125",
+        "completion": "0.0000012",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000005625",
+        "prompt": "0.0000008",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed",
+        "top_a"
+      ],
       "top_provider": {
-        "context_length": 8192,
+        "context_length": 4096,
         "is_moderated": false,
-        "max_completion_tokens": 1024
+        "max_completion_tokens": 4096
       }
     },
     {
@@ -8082,6 +11998,7 @@
       "context_length": 32768,
       "created": 1717718400,
       "description": "Qwen2 72B is a transformer-based model that excels in language understanding, multilingual capabilities, coding, mathematics, and reasoning.\n\nIt features SwiGLU activation, attention QKV bias, and group query attention. It is pretrained on extensive data with supervised finetuning and direct preference optimization.\n\nFor more details, see this [blog post](https://qwenlm.github.io/blog/qwen2/) and [GitHub repo](https://github.com/QwenLM/Qwen2).\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2-72B-Instruct",
       "id": "qwen/qwen-2-72b-instruct",
       "name": "Qwen 2 72B Instruct",
       "per_request_limits": null,
@@ -8093,6 +12010,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8115,6 +12045,7 @@
       "context_length": 7500,
       "created": 1738434304,
       "description": "Qwen VL Max is a visual understanding model with 7500 tokens context length. It excels in delivering optimal performance for a broader spectrum of complex tasks.\n",
+      "hugging_face_id": "",
       "id": "qwen/qwen-vl-max",
       "name": "Qwen: Qwen VL Max",
       "per_request_limits": null,
@@ -8126,6 +12057,14 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "response_format",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 7500,
         "is_moderated": false,
@@ -8148,6 +12087,7 @@
       "context_length": 7500,
       "created": 1738731255,
       "description": "Qwen's Enhanced Large Visual Language Model. Significantly upgraded for detailed recognition capabilities and text recognition abilities, supporting ultra-high pixel resolutions up to millions of pixels and extreme aspect ratios for image input. It delivers significant performance across a broad range of visual tasks.\n",
+      "hugging_face_id": "",
       "id": "qwen/qwen-vl-plus",
       "name": "Qwen: Qwen VL Plus",
       "per_request_limits": null,
@@ -8159,6 +12099,14 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "response_format",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 7500,
         "is_moderated": false,
@@ -8180,17 +12128,29 @@
       "context_length": 32768,
       "created": 1738402289,
       "description": "Qwen-Max, based on Qwen2.5, provides the best inference performance among [Qwen models](/qwen), especially for complex multi-step tasks. It's a large-scale MoE model that has been pretrained on over 20 trillion tokens and further post-trained with curated Supervised Fine-Tuning (SFT) and Reinforcement Learning from Human Feedback (RLHF) methodologies. The parameter count is unknown.",
+      "hugging_face_id": "",
       "id": "qwen/qwen-max",
       "name": "Qwen: Qwen-Max ",
       "per_request_limits": null,
       "pricing": {
         "completion": "0.0000064",
         "image": "0",
+        "input_cache_read": "0.00000064",
         "internal_reasoning": "0",
         "prompt": "0.0000016",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "response_format",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8212,17 +12172,29 @@
       "context_length": 131072,
       "created": 1738409840,
       "description": "Qwen-Plus, based on the Qwen2.5 foundation model, is a 131K context model with a balanced performance, speed, and cost combination.",
+      "hugging_face_id": "",
       "id": "qwen/qwen-plus",
       "name": "Qwen: Qwen-Plus",
       "per_request_limits": null,
       "pricing": {
         "completion": "0.0000012",
         "image": "0",
+        "input_cache_read": "0.00000016",
         "internal_reasoning": "0",
         "prompt": "0.0000004",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "response_format",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -8244,17 +12216,29 @@
       "context_length": 1000000,
       "created": 1738410974,
       "description": "Qwen-Turbo, based on Qwen2.5, is a 1M context model that provides fast speed and low cost, suitable for simple tasks.",
+      "hugging_face_id": "",
       "id": "qwen/qwen-turbo",
       "name": "Qwen: Qwen-Turbo",
       "per_request_limits": null,
       "pricing": {
         "completion": "0.0000002",
         "image": "0",
+        "input_cache_read": "0.00000002",
         "internal_reasoning": "0",
         "prompt": "0.00000005",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "response_format",
+        "presence_penalty"
+      ],
       "top_provider": {
         "context_length": 1000000,
         "is_moderated": false,
@@ -8276,21 +12260,35 @@
       "context_length": 32768,
       "created": 1744734887,
       "description": "Qwen2.5-Coder-7B-Instruct is a 7B parameter instruction-tuned language model optimized for code-related tasks such as code generation, reasoning, and bug fixing. Based on the Qwen2.5 architecture, it incorporates enhancements like RoPE, SwiGLU, RMSNorm, and GQA attention with support for up to 128K tokens using YaRN-based extrapolation. It is trained on a large corpus of source code, synthetic data, and text-code grounding, providing robust performance across programming languages and agentic coding workflows.\n\nThis model is part of the Qwen2.5-Coder family and offers strong compatibility with tools like vLLM for efficient deployment. Released under the Apache 2.0 license.",
+      "hugging_face_id": "Qwen/Qwen2.5-Coder-7B-Instruct",
       "id": "qwen/qwen2.5-coder-7b-instruct",
       "name": "Qwen: Qwen2.5 Coder 7B Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000002",
+        "completion": "0.00000003",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000002",
+        "prompt": "0.00000001",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 32768
+        "max_completion_tokens": null
       }
     },
     {
@@ -8309,6 +12307,7 @@
       "context_length": 128000,
       "created": 1742839838,
       "description": "Qwen2.5-VL-32B is a multimodal vision-language model fine-tuned through reinforcement learning for enhanced mathematical reasoning, structured outputs, and visual problem-solving capabilities. It excels at visual analysis tasks, including object recognition, textual interpretation within images, and precise event localization in extended videos. Qwen2.5-VL-32B demonstrates state-of-the-art performance across multimodal benchmarks such as MMMU, MathVista, and VideoMME, while maintaining strong reasoning and clarity in text-based tasks like MMLU, mathematical problem-solving, and code generation.",
+      "hugging_face_id": "Qwen/Qwen2.5-VL-32B-Instruct",
       "id": "qwen/qwen2.5-vl-32b-instruct",
       "name": "Qwen: Qwen2.5 VL 32B Instruct",
       "per_request_limits": null,
@@ -8320,6 +12319,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "response_format",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 128000,
         "is_moderated": false,
@@ -8342,6 +12356,7 @@
       "context_length": 8192,
       "created": 1742839838,
       "description": "Qwen2.5-VL-32B is a multimodal vision-language model fine-tuned through reinforcement learning for enhanced mathematical reasoning, structured outputs, and visual problem-solving capabilities. It excels at visual analysis tasks, including object recognition, textual interpretation within images, and precise event localization in extended videos. Qwen2.5-VL-32B demonstrates state-of-the-art performance across multimodal benchmarks such as MMMU, MathVista, and VideoMME, while maintaining strong reasoning and clarity in text-based tasks like MMLU, mathematical problem-solving, and code generation.",
+      "hugging_face_id": "Qwen/Qwen2.5-VL-32B-Instruct",
       "id": "qwen/qwen2.5-vl-32b-instruct:free",
       "name": "Qwen: Qwen2.5 VL 32B Instruct (free)",
       "per_request_limits": null,
@@ -8353,6 +12368,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "response_format",
+        "presence_penalty",
+        "stop",
+        "frequency_penalty",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -8375,6 +12406,7 @@
       "context_length": 64000,
       "created": 1743014573,
       "description": "Qwen2.5 VL 3B is a multimodal LLM from the Qwen Team with the following key enhancements:\n\n- SoTA understanding of images of various resolution & ratio: Qwen2.5-VL achieves state-of-the-art performance on visual understanding benchmarks, including MathVista, DocVQA, RealWorldQA, MTVQA, etc.\n\n- Agent that can operate your mobiles, robots, etc.: with the abilities of complex reasoning and decision making, Qwen2.5-VL can be integrated with devices like mobile phones, robots, etc., for automatic operation based on visual environment and text instructions.\n\n- Multilingual Support: to serve global users, besides English and Chinese, Qwen2.5-VL now supports the understanding of texts in different languages inside images, including most European languages, Japanese, Korean, Arabic, Vietnamese, etc.\n\nFor more details, see this [blog post](https://qwenlm.github.io/blog/qwen2-vl/) and [GitHub repo](https://github.com/QwenLM/Qwen2-VL).\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2.5-VL-3B-Instruct",
       "id": "qwen/qwen2.5-vl-3b-instruct:free",
       "name": "Qwen: Qwen2.5 VL 3B Instruct (free)",
       "per_request_limits": null,
@@ -8386,6 +12418,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 64000,
         "is_moderated": false,
@@ -8405,24 +12452,41 @@
         ],
         "tokenizer": "Qwen"
       },
-      "context_length": 128000,
+      "context_length": 32000,
       "created": 1738410311,
       "description": "Qwen2.5-VL is proficient in recognizing common objects such as flowers, birds, fish, and insects. It is also highly capable of analyzing texts, charts, icons, graphics, and layouts within images.",
+      "hugging_face_id": "Qwen/Qwen2.5-VL-72B-Instruct",
       "id": "qwen/qwen2.5-vl-72b-instruct",
       "name": "Qwen: Qwen2.5 VL 72B Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000007",
+        "completion": "0.00000075",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000007",
+        "prompt": "0.00000025",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "logprobs",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 128000,
+        "context_length": 32000,
         "is_moderated": false,
-        "max_completion_tokens": 128000
+        "max_completion_tokens": null
       }
     },
     {
@@ -8441,6 +12505,7 @@
       "context_length": 131072,
       "created": 1738410311,
       "description": "Qwen2.5-VL is proficient in recognizing common objects such as flowers, birds, fish, and insects. It is also highly capable of analyzing texts, charts, icons, graphics, and layouts within images.",
+      "hugging_face_id": "Qwen/Qwen2.5-VL-72B-Instruct",
       "id": "qwen/qwen2.5-vl-72b-instruct:free",
       "name": "Qwen: Qwen2.5 VL 72B Instruct (free)",
       "per_request_limits": null,
@@ -8452,6 +12517,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "seed",
+        "response_format",
+        "presence_penalty",
+        "stop",
+        "frequency_penalty",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -8472,19 +12553,35 @@
         "tokenizer": "Qwen"
       },
       "context_length": 32768,
-      "created": 1726617600,
-      "description": "Qwen2.5 VL 72B is a multimodal LLM from the Qwen Team with the following key enhancements:\n\n- SoTA understanding of images of various resolution & ratio: Qwen2.5-VL achieves state-of-the-art performance on visual understanding benchmarks, including MathVista, DocVQA, RealWorldQA, MTVQA, etc.\n\n- Understanding videos of 20min+: Qwen2.5-VL can understand videos over 20 minutes for high-quality video-based question answering, dialog, content creation, etc.\n\n- Agent that can operate your mobiles, robots, etc.: with the abilities of complex reasoning and decision making, Qwen2.5-VL can be integrated with devices like mobile phones, robots, etc., for automatic operation based on visual environment and text instructions.\n\n- Multilingual Support: to serve global users, besides English and Chinese, Qwen2.5-VL now supports the understanding of texts in different languages inside images, including most European languages, Japanese, Korean, Arabic, Vietnamese, etc.\n\nFor more details, see this [blog post](https://qwenlm.github.io/blog/qwen2-vl/) and [GitHub repo](https://github.com/QwenLM/Qwen2-VL).\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
-      "id": "qwen/qwen-2.5-vl-72b-instruct",
-      "name": "Qwen: Qwen2.5-VL 72B Instruct",
+      "created": 1724803200,
+      "description": "Qwen2.5 VL 7B is a multimodal LLM from the Qwen Team with the following key enhancements:\n\n- SoTA understanding of images of various resolution & ratio: Qwen2.5-VL achieves state-of-the-art performance on visual understanding benchmarks, including MathVista, DocVQA, RealWorldQA, MTVQA, etc.\n\n- Understanding videos of 20min+: Qwen2.5-VL can understand videos over 20 minutes for high-quality video-based question answering, dialog, content creation, etc.\n\n- Agent that can operate your mobiles, robots, etc.: with the abilities of complex reasoning and decision making, Qwen2.5-VL can be integrated with devices like mobile phones, robots, etc., for automatic operation based on visual environment and text instructions.\n\n- Multilingual Support: to serve global users, besides English and Chinese, Qwen2.5-VL now supports the understanding of texts in different languages inside images, including most European languages, Japanese, Korean, Arabic, Vietnamese, etc.\n\nFor more details, see this [blog post](https://qwenlm.github.io/blog/qwen2-vl/) and [GitHub repo](https://github.com/QwenLM/Qwen2-VL).\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2.5-VL-7B-Instruct",
+      "id": "qwen/qwen-2.5-vl-7b-instruct",
+      "name": "Qwen: Qwen2.5-VL 7B Instruct",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000006",
-        "image": "0.000578",
+        "completion": "0.0000002",
+        "image": "0.0001445",
         "internal_reasoning": "0",
-        "prompt": "0.0000006",
+        "prompt": "0.0000002",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8507,39 +12604,7 @@
       "context_length": 32768,
       "created": 1724803200,
       "description": "Qwen2.5 VL 7B is a multimodal LLM from the Qwen Team with the following key enhancements:\n\n- SoTA understanding of images of various resolution & ratio: Qwen2.5-VL achieves state-of-the-art performance on visual understanding benchmarks, including MathVista, DocVQA, RealWorldQA, MTVQA, etc.\n\n- Understanding videos of 20min+: Qwen2.5-VL can understand videos over 20 minutes for high-quality video-based question answering, dialog, content creation, etc.\n\n- Agent that can operate your mobiles, robots, etc.: with the abilities of complex reasoning and decision making, Qwen2.5-VL can be integrated with devices like mobile phones, robots, etc., for automatic operation based on visual environment and text instructions.\n\n- Multilingual Support: to serve global users, besides English and Chinese, Qwen2.5-VL now supports the understanding of texts in different languages inside images, including most European languages, Japanese, Korean, Arabic, Vietnamese, etc.\n\nFor more details, see this [blog post](https://qwenlm.github.io/blog/qwen2-vl/) and [GitHub repo](https://github.com/QwenLM/Qwen2-VL).\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
-      "id": "qwen/qwen-2.5-vl-7b-instruct",
-      "name": "Qwen: Qwen2.5-VL 7B Instruct",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.0000002",
-        "image": "0.0001445",
-        "internal_reasoning": "0",
-        "prompt": "0.0000002",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "instruct_type": null,
-        "modality": "text+image->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen"
-      },
-      "context_length": 64000,
-      "created": 1724803200,
-      "description": "Qwen2.5 VL 7B is a multimodal LLM from the Qwen Team with the following key enhancements:\n\n- SoTA understanding of images of various resolution & ratio: Qwen2.5-VL achieves state-of-the-art performance on visual understanding benchmarks, including MathVista, DocVQA, RealWorldQA, MTVQA, etc.\n\n- Understanding videos of 20min+: Qwen2.5-VL can understand videos over 20 minutes for high-quality video-based question answering, dialog, content creation, etc.\n\n- Agent that can operate your mobiles, robots, etc.: with the abilities of complex reasoning and decision making, Qwen2.5-VL can be integrated with devices like mobile phones, robots, etc., for automatic operation based on visual environment and text instructions.\n\n- Multilingual Support: to serve global users, besides English and Chinese, Qwen2.5-VL now supports the understanding of texts in different languages inside images, including most European languages, Japanese, Korean, Arabic, Vietnamese, etc.\n\nFor more details, see this [blog post](https://qwenlm.github.io/blog/qwen2-vl/) and [GitHub repo](https://github.com/QwenLM/Qwen2-VL).\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2.5-VL-7B-Instruct",
       "id": "qwen/qwen-2.5-vl-7b-instruct:free",
       "name": "Qwen: Qwen2.5-VL 7B Instruct (free)",
       "per_request_limits": null,
@@ -8551,10 +12616,581 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
-        "context_length": 64000,
+        "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 64000
+        "max_completion_tokens": 32768
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745876478,
+      "description": "Qwen3-14B is a dense 14.8B parameter causal language model from the Qwen3 series, designed for both complex reasoning and efficient dialogue. It supports seamless switching between a \"thinking\" mode for tasks like math, programming, and logical inference, and a \"non-thinking\" mode for general-purpose conversation. The model is fine-tuned for instruction-following, agent tool use, creative writing, and multilingual tasks across 100+ languages and dialects. It natively handles 32K token contexts and can extend to 131K tokens using YaRN-based scaling.",
+      "hugging_face_id": "Qwen/Qwen3-14B",
+      "id": "qwen/qwen3-14b",
+      "name": "Qwen: Qwen3 14B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000024",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000007",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": 40960
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745876478,
+      "description": "Qwen3-14B is a dense 14.8B parameter causal language model from the Qwen3 series, designed for both complex reasoning and efficient dialogue. It supports seamless switching between a \"thinking\" mode for tasks like math, programming, and logical inference, and a \"non-thinking\" mode for general-purpose conversation. The model is fine-tuned for instruction-following, agent tool use, creative writing, and multilingual tasks across 100+ languages and dialects. It natively handles 32K token contexts and can extend to 131K tokens using YaRN-based scaling.",
+      "hugging_face_id": "Qwen/Qwen3-14B",
+      "id": "qwen/qwen3-14b:free",
+      "name": "Qwen: Qwen3 14B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745875757,
+      "description": "Qwen3-235B-A22B is a 235B parameter mixture-of-experts (MoE) model developed by Qwen, activating 22B parameters per forward pass. It supports seamless switching between a \"thinking\" mode for complex reasoning, math, and code tasks, and a \"non-thinking\" mode for general conversational efficiency. The model demonstrates strong reasoning ability, multilingual support (100+ languages and dialects), advanced instruction-following, and agent tool-calling capabilities. It natively handles a 32K token context window and extends up to 131K tokens using YaRN-based scaling.",
+      "hugging_face_id": "Qwen/Qwen3-235B-A22B",
+      "id": "qwen/qwen3-235b-a22b",
+      "name": "Qwen: Qwen3 235B A22B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000006",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000014",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "top_k",
+        "tools",
+        "tool_choice",
+        "stop",
+        "response_format",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "min_p"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": 40960
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745875757,
+      "description": "Qwen3-235B-A22B is a 235B parameter mixture-of-experts (MoE) model developed by Qwen, activating 22B parameters per forward pass. It supports seamless switching between a \"thinking\" mode for complex reasoning, math, and code tasks, and a \"non-thinking\" mode for general conversational efficiency. The model demonstrates strong reasoning ability, multilingual support (100+ languages and dialects), advanced instruction-following, and agent tool-calling capabilities. It natively handles a 32K token context window and extends up to 131K tokens using YaRN-based scaling.",
+      "hugging_face_id": "Qwen/Qwen3-235B-A22B",
+      "id": "qwen/qwen3-235b-a22b:free",
+      "name": "Qwen: Qwen3 235B A22B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745878604,
+      "description": "Qwen3, the latest generation in the Qwen large language model series, features both dense and mixture-of-experts (MoE) architectures to excel in reasoning, multilingual support, and advanced agent tasks. Its unique ability to switch seamlessly between a thinking mode for complex reasoning and a non-thinking mode for efficient dialogue ensures versatile, high-quality performance.\n\nSignificantly outperforming prior models like QwQ and Qwen2.5, Qwen3 delivers superior mathematics, coding, commonsense reasoning, creative writing, and interactive dialogue capabilities. The Qwen3-30B-A3B variant includes 30.5 billion parameters (3.3 billion activated), 48 layers, 128 experts (8 activated per task), and supports up to 131K token contexts with YaRN, setting a new standard among open-source models.",
+      "hugging_face_id": "Qwen/Qwen3-30B-A3B",
+      "id": "qwen/qwen3-30b-a3b",
+      "name": "Qwen: Qwen3 30B A3B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000029",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000008",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "response_format",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "min_p"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": 40960
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745878604,
+      "description": "Qwen3, the latest generation in the Qwen large language model series, features both dense and mixture-of-experts (MoE) architectures to excel in reasoning, multilingual support, and advanced agent tasks. Its unique ability to switch seamlessly between a thinking mode for complex reasoning and a non-thinking mode for efficient dialogue ensures versatile, high-quality performance.\n\nSignificantly outperforming prior models like QwQ and Qwen2.5, Qwen3 delivers superior mathematics, coding, commonsense reasoning, creative writing, and interactive dialogue capabilities. The Qwen3-30B-A3B variant includes 30.5 billion parameters (3.3 billion activated), 48 layers, 128 experts (8 activated per task), and supports up to 131K token contexts with YaRN, setting a new standard among open-source models.",
+      "hugging_face_id": "Qwen/Qwen3-30B-A3B",
+      "id": "qwen/qwen3-30b-a3b:free",
+      "name": "Qwen: Qwen3 30B A3B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745875945,
+      "description": "Qwen3-32B is a dense 32.8B parameter causal language model from the Qwen3 series, optimized for both complex reasoning and efficient dialogue. It supports seamless switching between a \"thinking\" mode for tasks like math, coding, and logical inference, and a \"non-thinking\" mode for faster, general-purpose conversation. The model demonstrates strong performance in instruction-following, agent tool use, creative writing, and multilingual tasks across 100+ languages and dialects. It natively handles 32K token contexts and can extend to 131K tokens using YaRN-based scaling. ",
+      "hugging_face_id": "Qwen/Qwen3-32B",
+      "id": "qwen/qwen3-32b",
+      "name": "Qwen: Qwen3 32B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.0000003",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.0000001",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p",
+        "logprobs",
+        "top_logprobs",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745875945,
+      "description": "Qwen3-32B is a dense 32.8B parameter causal language model from the Qwen3 series, optimized for both complex reasoning and efficient dialogue. It supports seamless switching between a \"thinking\" mode for tasks like math, coding, and logical inference, and a \"non-thinking\" mode for faster, general-purpose conversation. The model demonstrates strong performance in instruction-following, agent tool use, creative writing, and multilingual tasks across 100+ languages and dialects. It natively handles 32K token contexts and can extend to 131K tokens using YaRN-based scaling. ",
+      "hugging_face_id": "Qwen/Qwen3-32B",
+      "id": "qwen/qwen3-32b:free",
+      "name": "Qwen: Qwen3 32B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 128000,
+      "created": 1746031104,
+      "description": "Qwen3-4B is a 4 billion parameter dense language model from the Qwen3 series, designed to support both general-purpose and reasoning-intensive tasks. It introduces a dual-mode architecture—thinking and non-thinking—allowing dynamic switching between high-precision logical reasoning and efficient dialogue generation. This makes it well-suited for multi-turn chat, instruction following, and complex agent workflows.",
+      "hugging_face_id": "Qwen/Qwen3-4B",
+      "id": "qwen/qwen3-4b:free",
+      "name": "Qwen: Qwen3 4B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 128000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 128000,
+      "created": 1745876632,
+      "description": "Qwen3-8B is a dense 8.2B parameter causal language model from the Qwen3 series, designed for both reasoning-heavy tasks and efficient dialogue. It supports seamless switching between \"thinking\" mode for math, coding, and logical inference, and \"non-thinking\" mode for general conversation. The model is fine-tuned for instruction-following, agent integration, creative writing, and multilingual use across 100+ languages and dialects. It natively supports a 32K token context window and can extend to 131K tokens with YaRN scaling.",
+      "hugging_face_id": "Qwen/Qwen3-8B",
+      "id": "qwen/qwen3-8b",
+      "name": "Qwen: Qwen3 8B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.000000138",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.000000035",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 128000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "qwen3",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3"
+      },
+      "context_length": 40960,
+      "created": 1745876632,
+      "description": "Qwen3-8B is a dense 8.2B parameter causal language model from the Qwen3 series, designed for both reasoning-heavy tasks and efficient dialogue. It supports seamless switching between \"thinking\" mode for math, coding, and logical inference, and \"non-thinking\" mode for general conversation. The model is fine-tuned for instruction-following, agent integration, creative writing, and multilingual use across 100+ languages and dialects. It natively supports a 32K token context window and can extend to 131K tokens with YaRN scaling.",
+      "hugging_face_id": "Qwen/Qwen3-8B",
+      "id": "qwen/qwen3-8b:free",
+      "name": "Qwen: Qwen3 8B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 40960,
+        "is_moderated": false,
+        "max_completion_tokens": 40960
       }
     },
     {
@@ -8572,6 +13208,7 @@
       "context_length": 131072,
       "created": 1741208814,
       "description": "QwQ is the reasoning model of the Qwen series. Compared with conventional instruction-tuned models, QwQ, which is capable of thinking and reasoning, can achieve significantly enhanced performance in downstream tasks, especially hard problems. QwQ-32B is the medium-sized reasoning model, which is capable of achieving competitive performance against state-of-the-art reasoning models, e.g., DeepSeek-R1, o1-mini.",
+      "hugging_face_id": "Qwen/QwQ-32B",
       "id": "qwen/qwq-32b",
       "name": "Qwen: QwQ 32B",
       "per_request_limits": null,
@@ -8583,6 +13220,27 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "tools",
+        "tool_choice",
+        "structured_outputs"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -8604,6 +13262,7 @@
       "context_length": 40000,
       "created": 1741208814,
       "description": "QwQ is the reasoning model of the Qwen series. Compared with conventional instruction-tuned models, QwQ, which is capable of thinking and reasoning, can achieve significantly enhanced performance in downstream tasks, especially hard problems. QwQ-32B is the medium-sized reasoning model, which is capable of achieving competitive performance against state-of-the-art reasoning models, e.g., DeepSeek-R1, o1-mini.",
+      "hugging_face_id": "Qwen/QwQ-32B",
       "id": "qwen/qwq-32b:free",
       "name": "Qwen: QwQ 32B (free)",
       "per_request_limits": null,
@@ -8615,6 +13274,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 40000,
         "is_moderated": false,
@@ -8636,51 +13312,35 @@
       "context_length": 32768,
       "created": 1732754541,
       "description": "QwQ-32B-Preview is an experimental research model focused on AI reasoning capabilities developed by the Qwen Team. As a preview release, it demonstrates promising analytical abilities while having several important limitations:\n\n1. **Language Mixing and Code-Switching**: The model may mix languages or switch between them unexpectedly, affecting response clarity.\n2. **Recursive Reasoning Loops**: The model may enter circular reasoning patterns, leading to lengthy responses without a conclusive answer.\n3. **Safety and Ethical Considerations**: The model requires enhanced safety measures to ensure reliable and secure performance, and users should exercise caution when deploying it.\n4. **Performance and Benchmark Limitations**: The model excels in math and coding but has room for improvement in other areas, such as common sense reasoning and nuanced language understanding.\n\n",
+      "hugging_face_id": "Qwen/QwQ-32B-Preview",
       "id": "qwen/qwq-32b-preview",
       "name": "Qwen: QwQ 32B Preview",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000002",
+        "completion": "0.00000027",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000002",
+        "prompt": "0.00000009",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "repetition_penalty"
+      ],
       "top_provider": {
         "context_length": 32768,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "deepseek-r1",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen"
-      },
-      "context_length": 16384,
-      "created": 1732754541,
-      "description": "QwQ-32B-Preview is an experimental research model focused on AI reasoning capabilities developed by the Qwen Team. As a preview release, it demonstrates promising analytical abilities while having several important limitations:\n\n1. **Language Mixing and Code-Switching**: The model may mix languages or switch between them unexpectedly, affecting response clarity.\n2. **Recursive Reasoning Loops**: The model may enter circular reasoning patterns, leading to lengthy responses without a conclusive answer.\n3. **Safety and Ethical Considerations**: The model requires enhanced safety measures to ensure reliable and secure performance, and users should exercise caution when deploying it.\n4. **Performance and Benchmark Limitations**: The model excels in math and coding but has room for improvement in other areas, such as common sense reasoning and nuanced language understanding.\n\n",
-      "id": "qwen/qwq-32b-preview:free",
-      "name": "Qwen: QwQ 32B Preview (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 16384,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -8700,6 +13360,7 @@
       "context_length": 32768,
       "created": 1726704000,
       "description": "Qwen2.5 72B is the latest series of Qwen large language models. Qwen2.5 brings the following improvements upon Qwen2:\n\n- Significantly more knowledge and has greatly improved capabilities in coding and mathematics, thanks to our specialized expert models in these domains.\n\n- Significant improvements in instruction following, generating long texts (over 8K tokens), understanding structured data (e.g, tables), and generating structured outputs especially JSON. More resilient to the diversity of system prompts, enhancing role-play implementation and condition-setting for chatbots.\n\n- Long-context Support up to 128K tokens and can generate up to 8K tokens.\n\n- Multilingual support for over 29 languages, including Chinese, English, French, Spanish, Portuguese, German, Italian, Russian, Japanese, Korean, Vietnamese, Thai, Arabic, and more.\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2.5-72B-Instruct",
       "id": "qwen/qwen-2.5-72b-instruct",
       "name": "Qwen2.5 72B Instruct",
       "per_request_limits": null,
@@ -8711,10 +13372,29 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "response_format",
+        "structured_outputs",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "seed",
+        "min_p"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -8732,6 +13412,7 @@
       "context_length": 32768,
       "created": 1726704000,
       "description": "Qwen2.5 72B is the latest series of Qwen large language models. Qwen2.5 brings the following improvements upon Qwen2:\n\n- Significantly more knowledge and has greatly improved capabilities in coding and mathematics, thanks to our specialized expert models in these domains.\n\n- Significant improvements in instruction following, generating long texts (over 8K tokens), understanding structured data (e.g, tables), and generating structured outputs especially JSON. More resilient to the diversity of system prompts, enhancing role-play implementation and condition-setting for chatbots.\n\n- Long-context Support up to 128K tokens and can generate up to 8K tokens.\n\n- Multilingual support for over 29 languages, including Chinese, English, French, Spanish, Portuguese, German, Italian, Russian, Japanese, Korean, Vietnamese, Thai, Arabic, and more.\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2.5-72B-Instruct",
       "id": "qwen/qwen-2.5-72b-instruct:free",
       "name": "Qwen2.5 72B Instruct (free)",
       "per_request_limits": null,
@@ -8743,6 +13424,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8764,6 +13460,7 @@
       "context_length": 32768,
       "created": 1729036800,
       "description": "Qwen2.5 7B is the latest series of Qwen large language models. Qwen2.5 brings the following improvements upon Qwen2:\n\n- Significantly more knowledge and has greatly improved capabilities in coding and mathematics, thanks to our specialized expert models in these domains.\n\n- Significant improvements in instruction following, generating long texts (over 8K tokens), understanding structured data (e.g, tables), and generating structured outputs especially JSON. More resilient to the diversity of system prompts, enhancing role-play implementation and condition-setting for chatbots.\n\n- Long-context Support up to 128K tokens and can generate up to 8K tokens.\n\n- Multilingual support for over 29 languages, including Chinese, English, French, Spanish, Portuguese, German, Italian, Russian, Japanese, Korean, Vietnamese, Thai, Arabic, and more.\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2.5-7B-Instruct",
       "id": "qwen/qwen-2.5-7b-instruct",
       "name": "Qwen2.5 7B Instruct",
       "per_request_limits": null,
@@ -8771,14 +13468,29 @@
         "completion": "0.0000001",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000005",
+        "prompt": "0.00000004",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "structured_outputs",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": null
       }
     },
     {
@@ -8796,6 +13508,7 @@
       "context_length": 32768,
       "created": 1729036800,
       "description": "Qwen2.5 7B is the latest series of Qwen large language models. Qwen2.5 brings the following improvements upon Qwen2:\n\n- Significantly more knowledge and has greatly improved capabilities in coding and mathematics, thanks to our specialized expert models in these domains.\n\n- Significant improvements in instruction following, generating long texts (over 8K tokens), understanding structured data (e.g, tables), and generating structured outputs especially JSON. More resilient to the diversity of system prompts, enhancing role-play implementation and condition-setting for chatbots.\n\n- Long-context Support up to 128K tokens and can generate up to 8K tokens.\n\n- Multilingual support for over 29 languages, including Chinese, English, French, Spanish, Portuguese, German, Italian, Russian, Japanese, Korean, Vietnamese, Thai, Arabic, and more.\n\nUsage of this model is subject to [Tongyi Qianwen LICENSE AGREEMENT](https://huggingface.co/Qwen/Qwen1.5-110B-Chat/blob/main/LICENSE).",
+      "hugging_face_id": "Qwen/Qwen2.5-7B-Instruct",
       "id": "qwen/qwen-2.5-7b-instruct:free",
       "name": "Qwen2.5 7B Instruct (free)",
       "per_request_limits": null,
@@ -8807,6 +13520,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8828,6 +13554,7 @@
       "context_length": 32768,
       "created": 1731368400,
       "description": "Qwen2.5-Coder is the latest series of Code-Specific Qwen large language models (formerly known as CodeQwen). Qwen2.5-Coder brings the following improvements upon CodeQwen1.5:\n\n- Significantly improvements in **code generation**, **code reasoning** and **code fixing**. \n- A more comprehensive foundation for real-world applications such as **Code Agents**. Not only enhancing coding capabilities but also maintaining its strengths in mathematics and general competencies.\n\nTo read more about its evaluation results, check out [Qwen 2.5 Coder's blog](https://qwenlm.github.io/blog/qwen2.5-coder-family/).",
+      "hugging_face_id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "id": "qwen/qwen-2.5-coder-32b-instruct",
       "name": "Qwen2.5 Coder 32B Instruct",
       "per_request_limits": null,
@@ -8835,14 +13562,31 @@
         "completion": "0.00000015",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000007",
+        "prompt": "0.00000006",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "top_a"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -8860,6 +13604,7 @@
       "context_length": 32768,
       "created": 1731368400,
       "description": "Qwen2.5-Coder is the latest series of Code-Specific Qwen large language models (formerly known as CodeQwen). Qwen2.5-Coder brings the following improvements upon CodeQwen1.5:\n\n- Significantly improvements in **code generation**, **code reasoning** and **code fixing**. \n- A more comprehensive foundation for real-world applications such as **Code Agents**. Not only enhancing coding capabilities but also maintaining its strengths in mathematics and general competencies.\n\nTo read more about its evaluation results, check out [Qwen 2.5 Coder's blog](https://qwenlm.github.io/blog/qwen2.5-coder-family/).",
+      "hugging_face_id": "Qwen/Qwen2.5-Coder-32B-Instruct",
       "id": "qwen/qwen-2.5-coder-32b-instruct:free",
       "name": "Qwen2.5 Coder 32B Instruct (free)",
       "per_request_limits": null,
@@ -8871,6 +13616,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8892,6 +13652,7 @@
       "context_length": 32768,
       "created": 1742481597,
       "description": "Qwerky-72B is a linear-attention RWKV variant of the Qwen 2.5 72B model, optimized to significantly reduce computational cost at scale. Leveraging linear attention, it achieves substantial inference speedups (>1000x) while retaining competitive accuracy on common benchmarks like ARC, HellaSwag, Lambada, and MMLU. It inherits knowledge and language support from Qwen 2.5, supporting approximately 30 languages, making it suitable for efficient inference in large-context applications.",
+      "hugging_face_id": "featherless-ai/Qwerky-72B",
       "id": "featherless/qwerky-72b:free",
       "name": "Qwerky 72B (free)",
       "per_request_limits": null,
@@ -8903,6 +13664,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8924,6 +13697,7 @@
       "context_length": 32768,
       "created": 1741812813,
       "description": "Reka Flash 3 is a general-purpose, instruction-tuned large language model with 21 billion parameters, developed by Reka. It excels at general chat, coding tasks, instruction-following, and function calling. Featuring a 32K context length and optimized through reinforcement learning (RLOO), it provides competitive performance comparable to proprietary models within a smaller parameter footprint. Ideal for low-latency, local, or on-device deployments, Reka Flash 3 is compact, supports efficient quantization (down to 11GB at 4-bit precision), and employs explicit reasoning tags (\"<reasoning>\") to indicate its internal thought process.\n\nReka Flash 3 is primarily an English model with limited multilingual understanding capabilities. The model weights are released under the Apache 2.0 license.",
+      "hugging_face_id": "RekaAI/reka-flash-3",
       "id": "rekaai/reka-flash-3:free",
       "name": "Reka: Flash 3 (free)",
       "per_request_limits": null,
@@ -8935,6 +13709,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -8953,24 +13744,39 @@
         ],
         "tokenizer": "Llama2"
       },
-      "context_length": 6144,
+      "context_length": 4096,
       "created": 1689984000,
       "description": "A recreation trial of the original MythoMax-L2-B13 but with updated models. #merge",
+      "hugging_face_id": "Undi95/ReMM-SLERP-L2-13B",
       "id": "undi95/remm-slerp-l2-13b",
       "name": "ReMM SLERP 13B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.000001125",
+        "completion": "0.0000012",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000005625",
+        "prompt": "0.0000008",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed",
+        "logit_bias",
+        "top_a"
+      ],
       "top_provider": {
-        "context_length": 6144,
+        "context_length": 4096,
         "is_moderated": false,
-        "max_completion_tokens": 1024
+        "max_completion_tokens": 4096
       }
     },
     {
@@ -8988,6 +13794,7 @@
       "context_length": 32768,
       "created": 1727654400,
       "description": "Rocinante 12B is designed for engaging storytelling and rich prose.\n\nEarly testers have reported:\n- Expanded vocabulary with unique and expressive word choices\n- Enhanced creativity for vivid narratives\n- Adventure-filled and captivating stories",
+      "hugging_face_id": "TheDrummer/Rocinante-12B-v1.1",
       "id": "thedrummer/rocinante-12b",
       "name": "Rocinante 12B",
       "per_request_limits": null,
@@ -8999,40 +13806,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 32768,
-        "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "vicuna",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama2"
-      },
-      "context_length": 4096,
-      "created": 1737195189,
-      "description": "Rogue Rose demonstrates strong capabilities in roleplaying and storytelling applications, potentially surpassing other models in the 103-120B parameter range. While it occasionally exhibits inconsistencies with scene logic, the overall interaction quality represents an advancement in natural language processing for creative applications.\n\nIt is a 120-layer frankenmerge model combining two custom 70B architectures from November 2023, derived from the [xwin-stellarbright-erp-70b-v2](https://huggingface.co/sophosympatheia/xwin-stellarbright-erp-70b-v2) base.\n",
-      "id": "sophosympatheia/rogue-rose-103b-v0.2:free",
-      "name": "Rogue Rose 103B v0.2 (free)",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 4096,
         "is_moderated": false,
         "max_completion_tokens": null
       }
@@ -9052,6 +13840,7 @@
       "context_length": 8192,
       "created": 1723507200,
       "description": "Lunaris 8B is a versatile generalist and roleplaying model based on Llama 3. It's a strategic merge of multiple models, designed to balance creativity with improved logic and general knowledge.\n\nCreated by [Sao10k](https://huggingface.co/Sao10k), this model aims to offer an improved experience over Stheno v3.2, with enhanced creativity and logical reasoning.\n\nFor best results, use with Llama 3 Instruct context template, temperature 1.4, and min_p 0.1.",
+      "hugging_face_id": "Sao10K/L3-8B-Lunaris-v1",
       "id": "sao10k/l3-lunaris-8b",
       "name": "Sao10K: Llama 3 8B Lunaris",
       "per_request_limits": null,
@@ -9063,6 +13852,20 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -9084,6 +13887,7 @@
       "context_length": 8192,
       "created": 1718668800,
       "description": "Euryale 70B v2.1 is a model focused on creative roleplay from [Sao10k](https://ko-fi.com/sao10k).\n\n- Better prompt adherence.\n- Better anatomy / spatial awareness.\n- Adapts much better to unique and custom formatting / reply formats.\n- Very creative, lots of unique swipes.\n- Is not restrictive during roleplays.",
+      "hugging_face_id": "Sao10K/L3-70B-Euryale-v2.1",
       "id": "sao10k/l3-euryale-70b",
       "name": "Sao10k: Llama 3 Euryale 70B v2.1",
       "per_request_limits": null,
@@ -9095,42 +13899,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
         "max_completion_tokens": 8192
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": null,
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3"
-      },
-      "context_length": 16000,
-      "created": 1736302854,
-      "description": "This is [Sao10K](/sao10k)'s experiment over [Euryale v2.2](/sao10k/l3.1-euryale-70b).",
-      "id": "sao10k/l3.1-70b-hanami-x1",
-      "name": "Sao10K: Llama 3.1 70B Hanami x1",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.000003",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.000003",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 16000,
-        "is_moderated": false,
-        "max_completion_tokens": null
       }
     },
     {
@@ -9148,6 +13933,7 @@
       "context_length": 131072,
       "created": 1724803200,
       "description": "Euryale L3.1 70B v2.2 is a model focused on creative roleplay from [Sao10k](https://ko-fi.com/sao10k). It is the successor of [Euryale L3 70B v2.1](/models/sao10k/l3-euryale-70b).",
+      "hugging_face_id": "Sao10K/L3.1-70B-Euryale-v2.2",
       "id": "sao10k/l3.1-euryale-70b",
       "name": "Sao10K: Llama 3.1 Euryale 70B v2.2",
       "per_request_limits": null,
@@ -9159,10 +13945,24 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -9180,6 +13980,7 @@
       "context_length": 131072,
       "created": 1734535928,
       "description": "Euryale L3.3 70B is a model focused on creative roleplay from [Sao10k](https://ko-fi.com/sao10k). It is the successor of [Euryale L3 70B v2.2](/models/sao10k/l3-euryale-70b).",
+      "hugging_face_id": "Sao10K/L3.3-70B-Euryale-v2.3",
       "id": "sao10k/l3.3-euryale-70b",
       "name": "Sao10K: Llama 3.3 Euryale 70B",
       "per_request_limits": null,
@@ -9191,10 +13992,24 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "top_k",
+        "seed",
+        "min_p",
+        "logit_bias"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -9212,6 +14027,7 @@
       "context_length": 32768,
       "created": 1744754858,
       "description": "Shisa V2 Llama 3.3 70B is a bilingual Japanese-English chat model fine-tuned by Shisa.AI on Meta’s Llama-3.3-70B-Instruct base. It prioritizes Japanese language performance while retaining strong English capabilities. The model was optimized entirely through post-training, using a refined mix of supervised fine-tuning (SFT) and DPO datasets including regenerated ShareGPT-style data, translation tasks, roleplaying conversations, and instruction-following prompts. Unlike earlier Shisa releases, this version avoids tokenizer modifications or extended pretraining.\n\nShisa V2 70B achieves leading Japanese task performance across a wide range of custom and public benchmarks, including JA MT Bench, ELYZA 100, and Rakuda. It supports a 128K token context length and integrates smoothly with inference frameworks like vLLM and SGLang. While it inherits safety characteristics from its base model, no additional alignment was applied. The model is intended for high-performance bilingual chat, instruction following, and translation tasks across JA/EN.",
+      "hugging_face_id": "shisa-ai/shisa-v2-llama3.3-70b",
       "id": "shisa-ai/shisa-v2-llama3.3-70b:free",
       "name": "Shisa AI: Shisa V2 Llama 3.3 70B  (free)",
       "per_request_limits": null,
@@ -9223,6 +14039,21 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -9244,6 +14075,7 @@
       "context_length": 16000,
       "created": 1731105083,
       "description": "SorcererLM is an advanced RP and storytelling model, built as a Low-rank 16-bit LoRA fine-tuned on [WizardLM-2 8x22B](/microsoft/wizardlm-2-8x22b).\n\n- Advanced reasoning and emotional intelligence for engaging and immersive interactions\n- Vivid writing capabilities enriched with spatial and contextual awareness\n- Enhanced narrative depth, promoting creative and dynamic storytelling",
+      "hugging_face_id": "rAIfle/SorcererLM-8x22b-bf16",
       "id": "raifle/sorcererlm-8x22b",
       "name": "SorcererLM 8x22B",
       "per_request_limits": null,
@@ -9255,42 +14087,23 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 16000,
         "is_moderated": false,
         "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "deepseek-r1",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other"
-      },
-      "context_length": 131072,
-      "created": 1742067611,
-      "description": "L3.3-Electra-R1-70 is the newest release of the Unnamed series. Built on a DeepSeek R1 Distill base, Electra-R1 integrates various models together to provide an intelligent and coherent model capable of providing deep character insights. Through proper prompting, the model demonstrates advanced reasoning capabilities and unprompted exploration of character inner thoughts and motivations. Read more about the model and [prompting here](https://huggingface.co/Steelskull/L3.3-Electra-R1-70b)",
-      "id": "steelskull/l3.3-electra-r1-70b",
-      "name": "SteelSkull: L3.3 Electra R1 70B",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.00000095",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.0000007",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "is_moderated": false,
-        "max_completion_tokens": 131072
       }
     },
     {
@@ -9308,6 +14121,7 @@
       "context_length": 131072,
       "created": 1741642290,
       "description": "Anubis Pro 105B v1 is an expanded and refined variant of Meta’s Llama 3.3 70B, featuring 50% additional layers and further fine-tuning to leverage its increased capacity. Designed for advanced narrative, roleplay, and instructional tasks, it demonstrates enhanced emotional intelligence, creativity, nuanced character portrayal, and superior prompt adherence compared to smaller models. Its larger parameter count allows for deeper contextual understanding and extended reasoning capabilities, optimized for engaging, intelligent, and coherent interactions.",
+      "hugging_face_id": "TheDrummer/Anubis-Pro-105B-v1",
       "id": "thedrummer/anubis-pro-105b-v1",
       "name": "TheDrummer: Anubis Pro 105B V1",
       "per_request_limits": null,
@@ -9319,6 +14133,15 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "top_k"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -9340,6 +14163,7 @@
       "context_length": 32768,
       "created": 1741636566,
       "description": "Skyfall 36B v2 is an enhanced iteration of Mistral Small 2501, specifically fine-tuned for improved creativity, nuanced writing, role-playing, and coherent storytelling.",
+      "hugging_face_id": "TheDrummer/Skyfall-36B-v2",
       "id": "thedrummer/skyfall-36b-v2",
       "name": "TheDrummer: Skyfall 36B V2",
       "per_request_limits": null,
@@ -9351,10 +14175,403 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "top_k"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
         "max_completion_tokens": 32768
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32000,
+      "created": 1744920915,
+      "description": "GLM-4-32B-0414 is a 32B bilingual (Chinese-English) open-weight language model optimized for code generation, function calling, and agent-style tasks. Pretrained on 15T of high-quality and reasoning-heavy data, it was further refined using human preference alignment, rejection sampling, and reinforcement learning. The model excels in complex reasoning, artifact generation, and structured output tasks, achieving performance comparable to GPT-4o and DeepSeek-V3-0324 across several benchmarks.",
+      "hugging_face_id": "THUDM/GLM-4-32B-0414",
+      "id": "thudm/glm-4-32b",
+      "name": "THUDM: GLM 4 32B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000024",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000024",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 32000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1744920915,
+      "description": "GLM-4-32B-0414 is a 32B bilingual (Chinese-English) open-weight language model optimized for code generation, function calling, and agent-style tasks. Pretrained on 15T of high-quality and reasoning-heavy data, it was further refined using human preference alignment, rejection sampling, and reinforcement learning. The model excels in complex reasoning, artifact generation, and structured output tasks, achieving performance comparable to GPT-4o and DeepSeek-V3-0324 across several benchmarks.",
+      "hugging_face_id": "THUDM/GLM-4-32B-0414",
+      "id": "thudm/glm-4-32b:free",
+      "name": "THUDM: GLM 4 32B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32000,
+      "created": 1745601023,
+      "description": "GLM-4-9B-0414 is a 9 billion parameter language model from the GLM-4 series developed by THUDM. Trained using the same reinforcement learning and alignment strategies as its larger 32B counterparts, GLM-4-9B-0414 achieves high performance relative to its size, making it suitable for resource-constrained deployments that still require robust language understanding and generation capabilities.",
+      "hugging_face_id": "THUDM/GLM-4-9B-0414",
+      "id": "thudm/glm-4-9b:free",
+      "name": "THUDM: GLM 4 9B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 32000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "deepseek-r1",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32000,
+      "created": 1744924148,
+      "description": "GLM-Z1-32B-0414 is an enhanced reasoning variant of GLM-4-32B, built for deep mathematical, logical, and code-oriented problem solving. It applies extended reinforcement learning—both task-specific and general pairwise preference-based—to improve performance on complex multi-step tasks. Compared to the base GLM-4-32B model, Z1 significantly boosts capabilities in structured reasoning and formal domains.\n\nThe model supports enforced “thinking” steps via prompt engineering and offers improved coherence for long-form outputs. It’s optimized for use in agentic workflows, and includes support for long context (via YaRN), JSON tool calling, and fine-grained sampling configuration for stable inference. Ideal for use cases requiring deliberate, multi-step reasoning or formal derivations.",
+      "hugging_face_id": "THUDM/GLM-Z1-32B-0414",
+      "id": "thudm/glm-z1-32b",
+      "name": "THUDM: GLM Z1 32B",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000024",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000024",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 32000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "deepseek-r1",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32768,
+      "created": 1744924148,
+      "description": "GLM-Z1-32B-0414 is an enhanced reasoning variant of GLM-4-32B, built for deep mathematical, logical, and code-oriented problem solving. It applies extended reinforcement learning—both task-specific and general pairwise preference-based—to improve performance on complex multi-step tasks. Compared to the base GLM-4-32B model, Z1 significantly boosts capabilities in structured reasoning and formal domains.\n\nThe model supports enforced “thinking” steps via prompt engineering and offers improved coherence for long-form outputs. It’s optimized for use in agentic workflows, and includes support for long context (via YaRN), JSON tool calling, and fine-grained sampling configuration for stable inference. Ideal for use cases requiring deliberate, multi-step reasoning or formal derivations.",
+      "hugging_face_id": "THUDM/GLM-Z1-32B-0414",
+      "id": "thudm/glm-z1-32b:free",
+      "name": "THUDM: GLM Z1 32B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 32768,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "deepseek-r1",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32000,
+      "created": 1745601140,
+      "description": "GLM-Z1-9B-0414 is a 9B-parameter language model developed by THUDM as part of the GLM-4 family. It incorporates techniques originally applied to larger GLM-Z1 models, including extended reinforcement learning, pairwise ranking alignment, and training on reasoning-intensive tasks such as mathematics, code, and logic. Despite its smaller size, it demonstrates strong performance on general-purpose reasoning tasks and outperforms many open-source models in its weight class.",
+      "hugging_face_id": "thudm/glm-z1-9b-0414",
+      "id": "thudm/glm-z1-9b:free",
+      "name": "THUDM: GLM Z1 9B (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 32000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": "deepseek-r1",
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other"
+      },
+      "context_length": 32000,
+      "created": 1745601495,
+      "description": "THUDM: GLM Z1 Rumination 32B is a 32B-parameter deep reasoning model from the GLM-4-Z1 series, optimized for complex, open-ended tasks requiring prolonged deliberation. It builds upon glm-4-32b-0414 with additional reinforcement learning phases and multi-stage alignment strategies, introducing “rumination” capabilities designed to emulate extended cognitive processing. This includes iterative reasoning, multi-hop analysis, and tool-augmented workflows such as search, retrieval, and citation-aware synthesis.\n\nThe model excels in research-style writing, comparative analysis, and intricate question answering. It supports function calling for search and navigation primitives (`search`, `click`, `open`, `finish`), enabling use in agent-style pipelines. Rumination behavior is governed by multi-turn loops with rule-based reward shaping and delayed decision mechanisms, benchmarked against Deep Research frameworks such as OpenAI’s internal alignment stacks. This variant is suitable for scenarios requiring depth over speed.",
+      "hugging_face_id": "THUDM/GLM-Z1-Rumination-32B-0414",
+      "id": "thudm/glm-z1-rumination-32b",
+      "name": "THUDM: GLM Z1 Rumination 32B ",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0.00000024",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0.00000024",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logit_bias"
+      ],
+      "top_provider": {
+        "context_length": 32000,
+        "is_moderated": false,
+        "max_completion_tokens": null
+      }
+    },
+    {
+      "architecture": {
+        "input_modalities": [
+          "text"
+        ],
+        "instruct_type": null,
+        "modality": "text->text",
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "DeepSeek"
+      },
+      "context_length": 163840,
+      "created": 1745760875,
+      "description": "DeepSeek-R1T-Chimera is created by merging DeepSeek-R1 and DeepSeek-V3 (0324), combining the reasoning capabilities of R1 with the token efficiency improvements of V3. It is based on a DeepSeek-MoE Transformer architecture and is optimized for general text generation tasks.\n\nThe model merges pretrained weights from both source models to balance performance across reasoning, efficiency, and instruction-following tasks. It is released under the MIT license and intended for research and commercial use.",
+      "hugging_face_id": "tngtech/DeepSeek-R1T-Chimera",
+      "id": "tngtech/deepseek-r1t-chimera:free",
+      "name": "TNG: DeepSeek R1T Chimera (free)",
+      "per_request_limits": null,
+      "pricing": {
+        "completion": "0",
+        "image": "0",
+        "internal_reasoning": "0",
+        "prompt": "0",
+        "request": "0",
+        "web_search": "0"
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "top_k",
+        "min_p",
+        "repetition_penalty",
+        "logprobs",
+        "logit_bias",
+        "top_logprobs"
+      ],
+      "top_provider": {
+        "context_length": 163840,
+        "is_moderated": false,
+        "max_completion_tokens": null
       }
     },
     {
@@ -9372,21 +14589,34 @@
       "context_length": 4096,
       "created": 1699574400,
       "description": "A wild 7B parameter model that merges several models using the new task_arithmetic merge method from mergekit.\nList of merged models:\n- NousResearch/Nous-Capybara-7B-V1.9\n- [HuggingFaceH4/zephyr-7b-beta](/models/huggingfaceh4/zephyr-7b-beta)\n- lemonilia/AshhLimaRP-Mistral-7B\n- Vulkane/120-Days-of-Sodom-LoRA-Mistral-7b\n- Undi95/Mistral-pippa-sharegpt-7b-qlora\n\n#merge #uncensored",
+      "hugging_face_id": "Undi95/Toppy-M-7B",
       "id": "undi95/toppy-m-7b",
       "name": "Toppy M 7B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.00000007",
+        "completion": "0.0000012",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.00000007",
+        "prompt": "0.0000008",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "top_k",
+        "min_p",
+        "seed"
+      ],
       "top_provider": {
         "context_length": 4096,
         "is_moderated": false,
-        "max_completion_tokens": null
+        "max_completion_tokens": 4096
       }
     },
     {
@@ -9404,6 +14634,7 @@
       "context_length": 8192,
       "created": 1743196170,
       "description": "Llama3.1-Typhoon2-70B-Instruct is a Thai-English instruction-tuned language model with 70 billion parameters, built on Llama 3.1. It demonstrates strong performance across general instruction-following, math, coding, and tool-use tasks, with state-of-the-art results in Thai-specific benchmarks such as IFEval, MT-Bench, and Thai-English code-switching.\n\nThe model excels in bilingual reasoning and function-calling scenarios, offering high accuracy across diverse domains. Comparative evaluations show consistent improvements over prior Thai LLMs and other Llama-based baselines. Full results and methodology are available in the [technical report.](https://arxiv.org/abs/2412.13702)",
+      "hugging_face_id": "scb10x/llama3.1-typhoon2-70b-instruct",
       "id": "scb10x/llama3.1-typhoon2-70b-instruct",
       "name": "Typhoon2 70B Instruct",
       "per_request_limits": null,
@@ -9415,6 +14646,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -9436,6 +14680,7 @@
       "context_length": 8192,
       "created": 1743196511,
       "description": "Llama3.1-Typhoon2-8B-Instruct is a Thai-English instruction-tuned model with 8 billion parameters, built on Llama 3.1. It significantly improves over its base model in Thai reasoning, instruction-following, and function-calling tasks, while maintaining competitive English performance. The model is optimized for bilingual interaction and performs well on Thai-English code-switching, MT-Bench, IFEval, and tool-use benchmarks.\n\nDespite its smaller size, it demonstrates strong generalization across math, coding, and multilingual benchmarks, outperforming comparable 8B models across most Thai-specific tasks. Full benchmark results and methodology are available in the [technical report.](https://arxiv.org/abs/2412.13702)",
+      "hugging_face_id": "scb10x/llama3.1-typhoon2-8b-instruct",
       "id": "scb10x/llama3.1-typhoon2-8b-instruct",
       "name": "Typhoon2 8B Instruct",
       "per_request_limits": null,
@@ -9447,6 +14692,19 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "top_k",
+        "repetition_penalty",
+        "logit_bias",
+        "min_p",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
@@ -9468,53 +14726,36 @@
       "context_length": 32000,
       "created": 1731103448,
       "description": "UnslopNemo v4.1 is the latest addition from the creator of Rocinante, designed for adventure writing and role-play scenarios.",
+      "hugging_face_id": "TheDrummer/UnslopNemo-12B-v4.1",
       "id": "thedrummer/unslopnemo-12b",
       "name": "Unslopnemo 12B",
       "per_request_limits": null,
       "pricing": {
-        "completion": "0.0000005",
+        "completion": "0.00000045",
         "image": "0",
         "internal_reasoning": "0",
-        "prompt": "0.0000005",
+        "prompt": "0.00000045",
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "logit_bias",
+        "top_k",
+        "min_p",
+        "seed",
+        "logprobs"
+      ],
       "top_provider": {
         "context_length": 32000,
         "is_moderated": false,
-        "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "vicuna",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral"
-      },
-      "context_length": 32000,
-      "created": 1713225600,
-      "description": "WizardLM-2 7B is the smaller variant of Microsoft AI's latest Wizard model. It is the fastest and achieves comparable performance with existing 10x larger opensource leading models\n\nIt is a finetune of [Mistral 7B Instruct](/models/mistralai/mistral-7b-instruct), using the same technique as [WizardLM-2 8x22B](/models/microsoft/wizardlm-2-8x22b).\n\nTo read more about the model release, [click here](https://wizardlm.github.io/WizardLM2/).\n\n#moe",
-      "id": "microsoft/wizardlm-2-7b",
-      "name": "WizardLM-2 7B",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.00000007",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.00000007",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 32000,
-        "is_moderated": false,
-        "max_completion_tokens": null
+        "max_completion_tokens": 16000
       }
     },
     {
@@ -9532,6 +14773,7 @@
       "context_length": 65536,
       "created": 1713225600,
       "description": "WizardLM-2 8x22B is Microsoft AI's most advanced Wizard model. It demonstrates highly competitive performance compared to leading proprietary models, and it consistently outperforms all existing state-of-the-art opensource models.\n\nIt is an instruct finetune of [Mixtral 8x22B](/models/mistralai/mixtral-8x22b).\n\nTo read more about the model release, [click here](https://wizardlm.github.io/WizardLM2/).\n\n#moe",
+      "hugging_face_id": "microsoft/WizardLM-2-8x22B",
       "id": "microsoft/wizardlm-2-8x22b",
       "name": "WizardLM-2 8x22B",
       "per_request_limits": null,
@@ -9543,10 +14785,24 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "presence_penalty",
+        "frequency_penalty",
+        "repetition_penalty",
+        "top_k",
+        "stop",
+        "seed",
+        "min_p",
+        "logit_bias",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 65536,
         "is_moderated": false,
-        "max_completion_tokens": 8192
+        "max_completion_tokens": 16384
       }
     },
     {
@@ -9564,6 +14820,7 @@
       "context_length": 131072,
       "created": 1734232814,
       "description": "Grok 2 1212 introduces significant enhancements to accuracy, instruction adherence, and multilingual support, making it a powerful and flexible choice for developers seeking a highly steerable, intelligent model.",
+      "hugging_face_id": "",
       "id": "x-ai/grok-2-1212",
       "name": "xAI: Grok 2 1212",
       "per_request_limits": null,
@@ -9575,6 +14832,20 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -9597,6 +14868,7 @@
       "context_length": 32768,
       "created": 1734237338,
       "description": "Grok 2 Vision 1212 advances image-based AI with stronger visual comprehension, refined instruction-following, and multilingual support. From object recognition to style analysis, it empowers developers to build more intuitive, visually aware applications. Its enhanced steerability and reasoning establish a robust foundation for next-generation image solutions.\n\nTo read more about this model, check out [xAI's announcement](https://x.ai/blog/grok-1212).",
+      "hugging_face_id": "",
       "id": "x-ai/grok-2-vision-1212",
       "name": "xAI: Grok 2 Vision 1212",
       "per_request_limits": null,
@@ -9608,6 +14880,18 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 32768,
         "is_moderated": false,
@@ -9629,6 +14913,7 @@
       "context_length": 131072,
       "created": 1744240068,
       "description": "Grok 3 is the latest model from xAI. It's their flagship model that excels at enterprise use cases like data extraction, coding, and text summarization. Possesses deep domain knowledge in finance, healthcare, law, and science.\n\nExcels in structured tasks and benchmarks like GPQA, LCB, and MMLU-Pro where it outperforms Grok 3 Mini even on high thinking. \n\nNote: That there are two xAI endpoints for this model. By default when using this model we will always route you to the base endpoint. If you want the fast endpoint you can add `provider: { sort: throughput}`, to sort by throughput instead. \n",
+      "hugging_face_id": "",
       "id": "x-ai/grok-3-beta",
       "name": "xAI: Grok 3 Beta",
       "per_request_limits": null,
@@ -9640,6 +14925,20 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -9661,6 +14960,7 @@
       "context_length": 131072,
       "created": 1744240195,
       "description": "Grok 3 Mini is a lightweight, smaller thinking model. Unlike traditional models that generate answers immediately, Grok 3 Mini thinks before responding. It’s ideal for reasoning-heavy tasks that don’t demand extensive domain knowledge, and shines in math-specific and quantitative use cases, such as solving challenging puzzles or math problems.\n\nTransparent \"thinking\" traces accessible. Defaults to low reasoning, can boost with setting `reasoning: { effort: \"high\" }`\n\nNote: That there are two xAI endpoints for this model. By default when using this model we will always route you to the base endpoint. If you want the fast endpoint you can add `provider: { sort: throughput}`, to sort by throughput instead. \n",
+      "hugging_face_id": "",
       "id": "x-ai/grok-3-mini-beta",
       "name": "xAI: Grok 3 Mini Beta",
       "per_request_limits": null,
@@ -9672,6 +14972,20 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "reasoning",
+        "include_reasoning",
+        "stop",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -9693,6 +15007,7 @@
       "context_length": 131072,
       "created": 1729382400,
       "description": "Grok Beta is xAI's experimental language model with state-of-the-art reasoning capabilities, best for complex and multi-step use cases.\n\nIt is the successor of [Grok 2](https://x.ai/blog/grok-2) with enhanced context length.",
+      "hugging_face_id": null,
       "id": "x-ai/grok-beta",
       "name": "xAI: Grok Beta",
       "per_request_limits": null,
@@ -9704,6 +15019,20 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "tools",
+        "tool_choice",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 131072,
         "is_moderated": false,
@@ -9726,6 +15055,7 @@
       "context_length": 8192,
       "created": 1731976624,
       "description": "Grok Vision Beta is xAI's experimental language model with vision capability.\n\n",
+      "hugging_face_id": "",
       "id": "x-ai/grok-vision-beta",
       "name": "xAI: Grok Vision Beta",
       "per_request_limits": null,
@@ -9737,42 +15067,22 @@
         "request": "0",
         "web_search": "0"
       },
+      "supported_parameters": [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "logprobs",
+        "top_logprobs",
+        "response_format"
+      ],
       "top_provider": {
         "context_length": 8192,
         "is_moderated": false,
         "max_completion_tokens": null
-      }
-    },
-    {
-      "architecture": {
-        "input_modalities": [
-          "text"
-        ],
-        "instruct_type": "airoboros",
-        "modality": "text->text",
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama2"
-      },
-      "context_length": 8192,
-      "created": 1697328000,
-      "description": "Xwin-LM aims to develop and open-source alignment tech for LLMs. Our first release, built-upon on the [Llama2](/models/${Model.Llama_2_13B_Chat}) base models, ranked TOP-1 on AlpacaEval. Notably, it's the first to surpass [GPT-4](/models/${Model.GPT_4}) on this benchmark. The project will be continuously updated.",
-      "id": "xwin-lm/xwin-lm-70b",
-      "name": "Xwin 70B",
-      "per_request_limits": null,
-      "pricing": {
-        "completion": "0.00000375",
-        "image": "0",
-        "internal_reasoning": "0",
-        "prompt": "0.00000375",
-        "request": "0",
-        "web_search": "0"
-      },
-      "top_provider": {
-        "context_length": 8192,
-        "is_moderated": false,
-        "max_completion_tokens": 512
       }
     }
   ]


### PR DESCRIPTION
This pull request adds the new Claude 4 range of models, [as announced today](https://www.anthropic.com/news/claude-4). 

You'll notice that the `models.json` file contains many new entries, and this is because of a change in the contents of the JSON configuration that OpenRouter provides. 

Thanks!